### PR TITLE
stop transpiling to IE11 compatible code

### DIFF
--- a/config/targets.js
+++ b/config/targets.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const browsers = [
+let browsers = [
   'last 1 Chrome versions',
   'last 1 Firefox versions',
   'last 1 Safari versions',
@@ -10,7 +10,11 @@ const isCI = Boolean(process.env.CI);
 const isProduction = process.env.EMBER_ENV === 'production';
 
 if (isCI || isProduction) {
-  browsers.push('ie 11');
+  browsers = [
+    'last 3 Chrome versions',
+    'last 3 Firefox versions',
+    'last 3 Safari versions',
+  ];
 }
 
 module.exports = {


### PR DESCRIPTION
IE11 is not supported so we can reduce building times and bundle sizes.