### PR TITLE
Update the loading templates

### DIFF
--- a/app/templates/index-loading.hbs
+++ b/app/templates/index-loading.hbs
@@ -1,0 +1,14 @@
+<div class="au-c-body-container au-c-body-container--scroll">
+  <div class="au-o-box">
+    <div class="au-o-grid au-o-grid--small">
+      <div class="au-o-grid__item au-u-2-5@medium">
+        <div class="au-c-content  au-u-margin-bottom">
+          <AuHeading @skin="2">
+            {{t "utility.appName"}}
+          </AuHeading>
+          <AuLoader @size="small" />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/templates/loading.hbs
+++ b/app/templates/loading.hbs
@@ -1,1 +1,2 @@
+<NavigationBar />
 <AuLoader @size="large" />

--- a/app/templates/road-sign-concepts/edit-loading.hbs
+++ b/app/templates/road-sign-concepts/edit-loading.hbs
@@ -1,7 +1,7 @@
 <AuToolbar class="au-o-box">
   <AuToolbarGroup>
     <AuHeading @skin="2">
-      {{t "roadSignConcept.name"}}
+      {{t "roadSignConcept.crud.edit"}}
     </AuHeading>
   </AuToolbarGroup>
 </AuToolbar>


### PR DESCRIPTION
This fixes a problem where typing in the search field caused the loading screen to show. It still isn't perfect though. Switching from a /road-sign-concepts/* route to the index page doesn't show a loading page now and that model hook can take a while to resolve. The main issue seems to be that loading pages aren't flexible enough, and we need to look into [alternatives](https://github.com/kaliber5/ember-loading).