### PR TITLE
Make sure the app deploys with dutch as the default language

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,0 +1,7 @@
+import Controller from '@ember/controller';
+
+export default class ApplicationController extends Controller {
+  queryParams = ['lang'];
+
+  lang = '';
+}

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,10 +1,17 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import config from 'mow-registry/config/environment';
 
 export default class ApplicationRoute extends Route {
   @service intl;
 
-  beforeModel() {
-    this.intl.setLocale(['en-us']);
+  model({ lang }) {
+    const supportedLocales = config.supportedLocales;
+    let defaultLocale =
+      supportedLocales[lang] !== undefined
+        ? supportedLocales[lang]
+        : config.defaultLocale;
+
+    this.intl.setLocale([defaultLocale]);
   }
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,11 +1,19 @@
 'use strict';
 
+const supportedLocales = {
+  nl: 'nl-be',
+  en: 'en-us',
+};
+
 module.exports = function (environment) {
   let ENV = {
     modulePrefix: 'mow-registry',
     environment,
     rootURL: '/',
     locationType: 'auto',
+    defaultLocale:
+      environment === 'production' ? supportedLocales.nl : supportedLocales.en,
+    supportedLocales,
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build


### PR DESCRIPTION
This makes "nl-be" the default language when doing production builds. Development builds still use "en-us" by default. It's possible to change the language by adding a `?lang=nl|en` query param to the url.