### PR TITLE
Split the search filter into 2 specific filters

### DIFF
--- a/app/controllers/road-sign-concepts/index.js
+++ b/app/controllers/road-sign-concepts/index.js
@@ -4,19 +4,20 @@ import { restartableTask, timeout } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 
 export default class RoadsignConceptsIndexController extends Controller {
-  queryParams = ['page', 'size', 'search', 'sort', 'category'];
+  queryParams = ['page', 'size', 'code', 'meaning', 'sort', 'category'];
 
   @tracked page = 0;
   @tracked size = 30;
-  @tracked search = '';
+  @tracked code = '';
+  @tracked meaning = '';
   @tracked category = null;
   @tracked sort = 'road-sign-concept-code';
 
   @restartableTask
-  *updateSearchFilterTask(event) {
+  *updateSearchFilterTask(queryParamProperty, event) {
     yield timeout(300);
 
-    this.search = event.target.value;
+    this[queryParamProperty] = event.target.value.trim();
     this.resetPagination();
   }
 

--- a/app/routes/road-sign-concepts/index.js
+++ b/app/routes/road-sign-concepts/index.js
@@ -6,7 +6,8 @@ export default class RoadsignConceptsIndexRoute extends Route {
   @service store;
 
   queryParams = {
-    search: { refreshModel: true },
+    code: { refreshModel: true },
+    meaning: { refreshModel: true },
     page: { refreshModel: true },
     size: { refreshModel: true },
     sort: { refreshModel: true },
@@ -23,8 +24,12 @@ export default class RoadsignConceptsIndexRoute extends Route {
       },
     };
 
-    if (params.search) {
-      query.filter = params.search;
+    if (params.code) {
+      query['filter[road-sign-concept-code]'] = params.code;
+    }
+
+    if (params.meaning) {
+      query['filter[meaning]'] = params.meaning;
     }
 
     if (params.category) {

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -54,6 +54,15 @@ td {
   right: $au-unit;
 }
 
+.road-sign-code-search {
+  width: 10rem;
+  min-width: unset;
+}
+
+.road-sign-meaning-search {
+  min-width: unset;
+}
+
 .category-select {
   min-width: 24rem;
 }

--- a/app/templates/road-sign-concepts/index.hbs
+++ b/app/templates/road-sign-concepts/index.hbs
@@ -15,6 +15,29 @@
           </AuHeading>
         </AuToolbarGroup>
         <AuToolbarGroup class="au-c-toolbar__group--center">
+          {{!-- Copied from the AuDataTable::TextSearch component since that doesn't support calling actions on input--}}
+          <div class="au-c-data-table__search road-sign-code-search">
+            <input
+              value={{this.code}}
+              placeholder={{t "roadSignConcept.crud.codeFilter"}}
+              class="au-c-input au-c-input--block"
+              {{on "input" (perform this.updateSearchFilterTask "code")}}
+            />
+            <span class="au-c-data-table__search-icon">
+              <AuIcon @icon="search" @size="large" />
+            </span>
+          </div>
+          <div class="au-c-data-table__search road-sign-meaning-search">
+            <input
+              value={{this.meaning}}
+              placeholder={{t "roadSignConcept.crud.meaningFilter"}}
+              class="au-c-input au-c-input--block"
+              {{on "input" (perform this.updateSearchFilterTask "meaning")}}
+            />
+            <span class="au-c-data-table__search-icon">
+              <AuIcon @icon="search" @size="large" />
+            </span>
+          </div>
           <label>
             <span class="au-u-hidden-visually">{{t "roadSignConcept.crud.categoryFilter"}}</span>
             <PowerSelect
@@ -29,18 +52,6 @@
               {{category.label}}
             </PowerSelect>
           </label>
-          {{!-- Copied from the AuDataTable::TextSearch component since that doesn't support calling actions on input--}}
-          <div class="au-c-data-table__search">
-            <input
-              value={{this.filter}}
-              placeholder={{t "roadSignConcept.crud.search"}}
-              class="au-c-input au-c-input--block"
-              {{on "input" (perform this.updateSearchFilterTask)}}
-            />
-            <span class="au-c-data-table__search-icon">
-              <AuIcon @icon="search" @size="large" />
-            </span>
-          </div>
           <LinkTo class="au-c-button" @route="road-sign-concepts.new">
             {{t "roadSignConcept.crud.new"}}
           </LinkTo>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -27,10 +27,11 @@ roadSignConcept:
   crud:
     create: Create road sign
     new: New Road Sign
-    search: Search for road sign
     noData: No Road Signs
     edit: Edit Road Sign
     delete: Delete Road Sign
+    codeFilter: Code
+    meaningFilter: Search by meaning
     categoryFilter: Filter by category
   landingPage:
     subtitle: Subtitle for card

--- a/translations/nl-be.yaml
+++ b/translations/nl-be.yaml
@@ -27,10 +27,11 @@ roadSignConcept:
   crud:
     create: Verkeersbord aanmaken
     new: Nieuw verkeersbord
-    search: Verkeersborden zoeken
     noData: Geen verkeersborden gevonden
     edit: Verkeersbord bewerken
     delete: Verkeersbord verwijderen
+    codeFilter: Code
+    meaningFilter: Zoeken op betekenis
     categoryFilter: Filteren op categorie
   landingPage:
     subtitle: Ondertitel voor kaart


### PR DESCRIPTION
Users want to search on specific codes. The previous implementation didn't yield the correct result most of the time.