### PR TITLE
Fix measure relations not deleted properly

### DIFF
--- a/app/components/traffic-measure/index.js
+++ b/app/components/traffic-measure/index.js
@@ -275,7 +275,8 @@ export default class TrafficMeasureIndexComponent extends Component {
   @task
   *saveRoadsigns(trafficMeasureConcept) {
     // delete existing ones
-    for (let i = 0; i < trafficMeasureConcept.relations.length; i++) {
+    let length = trafficMeasureConcept.relations.length;
+    for (let i = 0; i < length; i++) {
       const relation = trafficMeasureConcept.relations.objectAt(0);
       yield relation.destroyRecord();
     }


### PR DESCRIPTION
**_How to reproduce the bug:_**
- Add 3 signs to a measure
- Save
- Delete 1
- Save

-> In the network tab, we can see that instead of deleting the 3 and then re adding 2, we're only deleting 2 because of a bug in the loop : the length goes down when destroying records so we can't reach the total length of the initial relationships array.

We didn't notice because we clear the relations before saving some new with `trafficMeasureConcept.relations = [];`, but that lead into some dangling data in the db.