### PR TITLE
Issue GN-3185: Bug on removing signs

### DIFF
--- a/app/controllers/codelists-management/codelist.js
+++ b/app/controllers/codelists-management/codelist.js
@@ -7,11 +7,6 @@ export default class CodelistController extends Controller {
   @service router;
   @tracked isOpen = false;
 
-  //@action
-  //toggleIsOpen() {
-  //  this.isOpen = !this.isOpen;
-  //}
-
   @action
   async removeCodelist(event) {
     event.preventDefault();

--- a/app/controllers/codelists-management/codelist.js
+++ b/app/controllers/codelists-management/codelist.js
@@ -7,10 +7,10 @@ export default class CodelistController extends Controller {
   @service router;
   @tracked isOpen = false;
 
-  @action
-  toggleIsOpen() {
-    this.isOpen = !this.isOpen;
-  }
+  //@action
+  //toggleIsOpen() {
+  //  this.isOpen = !this.isOpen;
+  //}
 
   @action
   async removeCodelist(event) {
@@ -25,6 +25,6 @@ export default class CodelistController extends Controller {
   }
 
   reset() {
-    this.isOpen = null;
+    this.isOpen = false;
   }
 }

--- a/app/controllers/road-marking-concepts/road-marking-concept.js
+++ b/app/controllers/road-marking-concepts/road-marking-concept.js
@@ -8,6 +8,7 @@ export default class RoadmarkingConceptsRoadmarkingConceptController extends Con
 
   @tracked isAddingRelatedRoadMarkings = false;
   @tracked isAddingRelatedRoadSigns = false;
+  @tracked isOpen = false;
 
   @tracked category = null;
   @tracked categoryRoadMarkings = null;
@@ -163,6 +164,7 @@ export default class RoadmarkingConceptsRoadmarkingConceptController extends Con
     this.editedTemplate = null;
     this.isAddingRelatedRoadMarkings = false;
     this.isAddingRelatedRoadSigns = false;
+    this.isOpen = false;
     this.category = null;
     this.categoryRoadMarkings = null;
   }

--- a/app/controllers/road-sign-concepts/road-sign-concept.js
+++ b/app/controllers/road-sign-concepts/road-sign-concept.js
@@ -9,6 +9,7 @@ export default class RoadsignConceptsRoadsignConceptController extends Controlle
   @tracked isAddingSubSigns = false;
   @tracked isAddingMainSigns = false;
   @tracked isAddingRelatedRoadSigns = false;
+  @tracked isOpen = false;
 
   @tracked category = null;
   @tracked categoryRoadSigns = null;
@@ -16,8 +17,6 @@ export default class RoadsignConceptsRoadsignConceptController extends Controlle
   @tracked subSignCodeFilter = '';
   @tracked newDescription = '';
   @tracked editedTemplate;
-
-  @tracked isOpen = false;
 
   get showSidebar() {
     return (
@@ -219,8 +218,8 @@ export default class RoadsignConceptsRoadsignConceptController extends Controlle
     this.isAddingSubSigns = false;
     this.isAddingMainSigns = false;
     this.isAddingRelatedRoadSigns = false;
+    this.isOpen = false;
     this.category = null;
     this.categoryRoadSigns = null;
-    this.isOpen = false;
   }
 }

--- a/app/controllers/road-sign-concepts/road-sign-concept.js
+++ b/app/controllers/road-sign-concepts/road-sign-concept.js
@@ -17,6 +17,8 @@ export default class RoadsignConceptsRoadsignConceptController extends Controlle
   @tracked newDescription = '';
   @tracked editedTemplate;
 
+  @tracked isOpen = false;
+
   get showSidebar() {
     return (
       this.isAddingRelatedRoadSigns ||
@@ -219,5 +221,6 @@ export default class RoadsignConceptsRoadsignConceptController extends Controlle
     this.isAddingRelatedRoadSigns = false;
     this.category = null;
     this.categoryRoadSigns = null;
+    this.isOpen = false;
   }
 }

--- a/app/controllers/traffic-light-concepts/traffic-light-concept.js
+++ b/app/controllers/traffic-light-concepts/traffic-light-concept.js
@@ -10,6 +10,7 @@ export default class RoadsignConceptsRoadsignConceptController extends Controlle
   @tracked isAddingSubSigns = false;
   @tracked isAddingMainSigns = false;
   @tracked isAddingRelatedTrafficLights = false;
+  @tracked isOpen = false;
 
   @tracked category = null;
   @tracked categoryTrafficLights = null;
@@ -187,6 +188,7 @@ export default class RoadsignConceptsRoadsignConceptController extends Controlle
     this.isAddingSubSigns = false;
     this.isAddingMainSigns = false;
     this.isAddingRelatedTrafficLights = false;
+    this.isOpen = false;
     // this.category = null;
     // this.categoryTrafficLights = null;
   }

--- a/app/routes/codelists-management/codelist.js
+++ b/app/routes/codelists-management/codelist.js
@@ -12,4 +12,8 @@ export default class CodelistsManagementCodelistRoute extends Route {
 
     return model;
   }
+
+  resetController(controller) {
+    controller.reset();
+  }
 }

--- a/app/templates/codelists-management/codelist.hbs
+++ b/app/templates/codelists-management/codelist.hbs
@@ -68,14 +68,14 @@
     <AuButton
       @skin="secondary"
       @alert={{true}}
-      {{on "click" this.toggleIsOpen}}
+      {{on "click" (fn (mut this.isOpen) true)}}
     >
       {{t "codelist.crud.delete"}}
     </AuButton>
     <AuModal
       @modalTitle={{t "utility.confirmation.title"}}
       @modalOpen={{this.isOpen}}
-      @closeModal={{this.toggleIsOpen}} as |Modal|
+      @closeModal={{fn (mut this.isOpen) false}} as |Modal|
     >
       <Modal.Body>
         <p>
@@ -96,7 +96,7 @@
           @skin="secondary"
           {{on
             "click"
-            this.toggleIsOpen
+            (fn (mut this.isOpen) false)
           }}
         >
           {{t "utility.cancel"}}


### PR DESCRIPTION
After removing a sign, the remove confirmation dialog remained open upon
viewing another sign. This behaviour is corrected by properly adding a
isOpen property on the controller and resetting that property on resetting
the controller.