### PR TITLE
absolute image paths, please read inside

### DIFF
--- a/app/components/road-sign-form.js
+++ b/app/components/road-sign-form.js
@@ -3,6 +3,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { dropTask } from 'ember-concurrency';
 import RoadSignConceptValidations from 'mow-registry/validations/road-sign-concept';
+import ENV from 'mow-registry/config/environment';
 
 export default class RoadSignFormComponent extends Component {
   @service router;
@@ -42,8 +43,14 @@ export default class RoadSignFormComponent extends Component {
     event.preventDefault();
 
     if (this.file) {
+      debugger;
       let fileResponse = yield this.fileService.upload(this.file);
-      roadSignConcept.image = fileResponse.downloadLink;
+      if(ENV.baseUrl != '{{BASE_URL}}'){
+        roadSignConcept.image = ENV.baseUrl + fileResponse.downloadLink;
+      }
+      else {
+        roadSignConcept.image = 'http://localhost'+fileResponse.downloadLink;
+      }
     }
 
     yield roadSignConcept.validate();

--- a/app/components/road-sign-form.js
+++ b/app/components/road-sign-form.js
@@ -43,13 +43,11 @@ export default class RoadSignFormComponent extends Component {
     event.preventDefault();
 
     if (this.file) {
-      debugger;
       let fileResponse = yield this.fileService.upload(this.file);
-      if(ENV.baseUrl != '{{BASE_URL}}'){
+      if (ENV.baseUrl != '{{BASE_URL}}') {
         roadSignConcept.image = ENV.baseUrl + fileResponse.downloadLink;
-      }
-      else {
-        roadSignConcept.image = 'http://localhost'+fileResponse.downloadLink;
+      } else {
+        roadSignConcept.image = 'http://localhost' + fileResponse.downloadLink;
       }
     }
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -46,7 +46,7 @@ module.exports = function (environment) {
       // Here you can pass flags/options to your application instance
       // when it is created
     },
-    baseUrl: '{{BASE_URL}}'
+    baseUrl: '{{BASE_URL}}',
   };
 
   if (environment === 'development') {

--- a/config/environment.js
+++ b/config/environment.js
@@ -46,6 +46,7 @@ module.exports = function (environment) {
       // Here you can pass flags/options to your application instance
       // when it is created
     },
+    baseUrl: '{{BASE_URL}}'
   };
 
   if (environment === 'development') {


### PR DESCRIPTION
So in order to fix all paths on all environments a couple of steps need to be taken...

1. all environments need to run this migration (replace http://localhost with whatever the env url is)

```
DELETE {
  GRAPH ?g{
    ?id <https://data.vlaanderen.be/ns/mobiliteit#grafischeWeergave> ?path.
  }
}
INSERT {
  GRAPH ?g{
    ?id <https://data.vlaanderen.be/ns/mobiliteit#grafischeWeergave> ?newPath.
  }
}
WHERE{ 
  GRAPH ?g{
    ?id <https://data.vlaanderen.be/ns/mobiliteit#grafischeWeergave> ?path.
    #filters out absolute paths leaving only relative ones
    FILTER regex(?path, '^(?!(?:[a-z]+:)?//)', 'i')
    BIND (concat("http://localhost", ?path) AS ?newPath)
  }
}
```
2. all environments need to have this commit merged and have the following in the docker-compose.override.yml (replace http://localhost with whatever the env url is)
```
frontend:
    environment:
      BASE_URL: "http://localhost/"
```
