### PR TITLE
added svg to upload types

### DIFF
--- a/app/components/file-uploader.js
+++ b/app/components/file-uploader.js
@@ -2,6 +2,6 @@ import Component from '@glimmer/component';
 
 export default class FileUploaderComponent extends Component {
   get accept() {
-    return this.args.accept || 'image/jpeg,image/jpg,image/png';
+    return this.args.accept || 'image/jpeg,image/jpg,image/png,image/svg+xml';
   }
 }

--- a/app/components/road-marking-form.hbs
+++ b/app/components/road-marking-form.hbs
@@ -58,7 +58,7 @@
                   {{t "utility.or"}}
                 </span>
                 <FileUploader
-                  @accept={{"image/png,image/jpg"}}
+                  @accept={{"image/jpeg,image/jpg,image/png,image/svg+xml"}}
                   @onFileSet={{fn this.setImageUpload roadMarkingConcept}}
                 />
                 {{#if isInvalid}}

--- a/app/components/road-sign-form.hbs
+++ b/app/components/road-sign-form.hbs
@@ -65,7 +65,7 @@
                   {{t "utility.or"}}
                 </span>
                 <FileUploader
-                  @accept={{"image/png,image/jpg"}}
+                  @accept={{"image/jpeg,image/jpg,image/png,image/svg+xml"}}
                   @onFileSet={{fn this.setImageUpload roadSignConcept}}
                 />
                 {{#if isInvalid}}

--- a/app/components/traffic-light-form.hbs
+++ b/app/components/traffic-light-form.hbs
@@ -62,7 +62,7 @@
                   {{t "utility.or"}}
                 </span>
                 <FileUploader
-                  @accept={{"image/png,image/jpg"}}
+                  @accept={{"image/jpeg,image/jpg,image/png,image/svg+xml"}}
                   @onFileSet={{fn this.setImageUpload trafficLightConcept}}
                 />
                 {{#if isInvalid}}


### PR DESCRIPTION
sooo actually file types dont seem to be inforced, you can choose "all file types" in the os file browser and upload a pdf if you wanted to... is this configurable in any way via the dispatcher for the file service? well anyway this will atleast allow them to select any image types without changing ths os filetype filter