### PR TITLE
Downgrade of ember-data to 3.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+
+## 0.15.0 (2022-09-06)
+
+#### :rocket: Enhancement
+* [#131](https://github.com/lblod/frontend-mow-registry/pull/131) Feature/environment banner ([@elpoelma](https://github.com/elpoelma))
+
+#### :bug: Bug Fix
+* [#128](https://github.com/lblod/frontend-mow-registry/pull/128) Bugfix/problems in codelist management ([@lagartoverde](https://github.com/lagartoverde))
+
+#### :house: Internal
+* [#130](https://github.com/lblod/frontend-mow-registry/pull/130) Update ember appuniversum to 1.4.1 ([@elpoelma](https://github.com/elpoelma))
+* [#129](https://github.com/lblod/frontend-mow-registry/pull/129) update to ember 3.28 lts ([@elpoelma](https://github.com/elpoelma))
+
+#### Committers: 2
+- Elena Poelman ([@elpoelma](https://github.com/elpoelma))
+- Oscar Rodriguez Villalobos ([@lagartoverde](https://github.com/lagartoverde))
+
+
 ## 0.14.1 (2022-07-08)
 
 #### :bug: Bug Fix

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mow-registry",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mow-registry",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "@lblod/ember-acmidm-login": "github:lblod/ember-acmidm-login#enhancement/iframe-login",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "ember-cli-terser": "^4.0.2",
         "ember-concurrency": "^2.0.2",
         "ember-config-helper": "^0.1.4",
-        "ember-data": "~3.28.6",
+        "ember-data": "~3.27.1",
         "ember-drag-drop": "^0.9.0-beta.0",
         "ember-export-application-global": "^2.0.1",
         "ember-fetch": "^8.1.1",
@@ -2285,21 +2285,21 @@
       }
     },
     "node_modules/@ember-data/adapter": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-3.28.10.tgz",
-      "integrity": "sha512-/ocqzP2dPw/wTUMiE0A5YE5lUvUVLslnKCTQYLCmgKYhBaKihAiyhrug2XXHsUsi065GODuY9tpt2YO+mGiotQ==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-3.27.1.tgz",
+      "integrity": "sha512-g9JPXn2QvV47xFWbY7xRiVp4LEbE4vkVo/qu3NtrvD+MLHNmfWn6VHhx2+v5mQB0pBe8lK8nPZGoS8PM/3CMuA==",
       "dev": true,
       "dependencies": {
-        "@ember-data/private-build-infra": "3.28.10",
-        "@ember-data/store": "3.28.10",
+        "@ember-data/private-build-infra": "3.27.1",
+        "@ember-data/store": "3.27.1",
         "@ember/edition-utils": "^1.2.0",
-        "@ember/string": "^3.0.0",
+        "@ember/string": "^1.0.0",
         "ember-cli-babel": "^7.26.6",
         "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^4.1.0"
+        "ember-cli-typescript": "^4.0.0"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
+        "node": "10.* || >= 12.*"
       }
     },
     "node_modules/@ember-data/adapter/node_modules/debug": {
@@ -2434,16 +2434,16 @@
       }
     },
     "node_modules/@ember-data/canary-features": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/canary-features/-/canary-features-3.28.10.tgz",
-      "integrity": "sha512-QaRMNSzsH1XvwCKyCXlimZhVSYAcs1x42cBemaiRMg5/LDrDZKMhWbFTNomM/k+0D2a0zHsCO91FXG8m1K19qQ==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@ember-data/canary-features/-/canary-features-3.27.1.tgz",
+      "integrity": "sha512-7RLYG1W1woBu116h4bE3zfEHCV+EVVzNZcgRD3tUH9cg/EvOfXfn3naAFNnoA7TIEl2ZShRPgNNi2SjkYYy52Q==",
       "dev": true,
       "dependencies": {
         "ember-cli-babel": "^7.26.6",
         "ember-cli-typescript": "^4.1.0"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
+        "node": "10.* || >= 12.*"
       }
     },
     "node_modules/@ember-data/canary-features/node_modules/debug": {
@@ -2578,20 +2578,20 @@
       }
     },
     "node_modules/@ember-data/debug": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/debug/-/debug-3.28.10.tgz",
-      "integrity": "sha512-smR2X8J0jycq5i3og0nFrYEEbwxjUPcXJ75tlAz9Rahqxz6U3UWAv29TKBNVUFeDQvJuOvdLzcfLK9YZ9i9bxQ==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@ember-data/debug/-/debug-3.27.1.tgz",
+      "integrity": "sha512-VWAzZFqKiheMc7Qx5yIekpdfamSBWURjNF5NKCQGGLRv7SsQe1eOjbW5iaq+gsnNr/gk4U95yLd225kUf6ubEQ==",
       "dev": true,
       "dependencies": {
-        "@ember-data/private-build-infra": "3.28.10",
+        "@ember-data/private-build-infra": "3.27.1",
         "@ember/edition-utils": "^1.2.0",
-        "@ember/string": "^3.0.0",
+        "@ember/string": "^1.0.0",
         "ember-cli-babel": "^7.26.6",
         "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^4.1.0"
+        "ember-cli-typescript": "^4.0.0"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
+        "node": "10.* || >= 12.*"
       }
     },
     "node_modules/@ember-data/debug/node_modules/debug": {
@@ -2726,26 +2726,25 @@
       }
     },
     "node_modules/@ember-data/model": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-3.28.10.tgz",
-      "integrity": "sha512-k72fqbKjSSmDHLGr0U/kHRsFI7gamN2nMGs0Qh1c2ZPR7CLXaNUCOQnJ/itxRInTX8WO996hjMUB+IMiKqfwYQ==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-3.27.1.tgz",
+      "integrity": "sha512-GC5bf2wAad6ePCoreOj4JknJaJ62FBwR9q+/zFxADU1Ns68kyVm/Xg7KD1sDvcXEwLJebH09j9sN7LkwZaN3Og==",
       "dev": true,
       "dependencies": {
-        "@ember-data/canary-features": "3.28.10",
-        "@ember-data/private-build-infra": "3.28.10",
-        "@ember-data/store": "3.28.10",
+        "@ember-data/canary-features": "3.27.1",
+        "@ember-data/private-build-infra": "3.27.1",
+        "@ember-data/store": "3.27.1",
         "@ember/edition-utils": "^1.2.0",
-        "@ember/string": "^3.0.0",
-        "ember-cached-decorator-polyfill": "^0.1.4",
+        "@ember/string": "^1.0.0",
         "ember-cli-babel": "^7.26.6",
         "ember-cli-string-utils": "^1.1.0",
         "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^4.1.0",
+        "ember-cli-typescript": "^4.0.0",
         "ember-compatibility-helpers": "^1.2.0",
-        "inflection": "~1.13.1"
+        "inflection": "1.12.0"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
+        "node": "10.* || >= 12.*"
       }
     },
     "node_modules/@ember-data/model/node_modules/debug": {
@@ -2824,6 +2823,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/@ember-data/model/node_modules/inflection": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
+      "integrity": "sha512-lRy4DxuIFWXlJU7ed8UiTJOSTqStqYdEb4CEbtXfNbkdj3nH1L+reUWiE10VWcJS2yR7tge8Z74pJjtBjNwj0w==",
+      "dev": true,
+      "engines": [
+        "node >= 0.4.0"
+      ]
+    },
     "node_modules/@ember-data/model/node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -2880,28 +2888,28 @@
       }
     },
     "node_modules/@ember-data/private-build-infra": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/private-build-infra/-/private-build-infra-3.28.10.tgz",
-      "integrity": "sha512-Fd9n2SOsndFOuDISkYQZsWRkif8gu0UG/1Yvloy3eOAPNLJBbGovZOFRgO4bxcPg3iHUl6THbYSLl/rXYv/Xiw==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@ember-data/private-build-infra/-/private-build-infra-3.27.1.tgz",
+      "integrity": "sha512-Cox/CRovg1gFGuO2zn64JSAezbbO1XHP+tLWDXRIiB2Oqlk3CtNxEs9K02DxMCojK4C8itFDOVpBKLYCB5MbYQ==",
       "dev": true,
       "dependencies": {
         "@babel/plugin-transform-block-scoping": "^7.8.3",
-        "@ember-data/canary-features": "3.28.10",
+        "@ember-data/canary-features": "3.27.1",
         "@ember/edition-utils": "^1.2.0",
         "babel-plugin-debug-macros": "^0.3.3",
         "babel-plugin-filter-imports": "^4.0.0",
         "babel6-plugin-strip-class-callcheck": "^6.0.0",
         "broccoli-debug": "^0.6.5",
         "broccoli-file-creator": "^2.1.1",
-        "broccoli-funnel": "^3.0.3",
+        "broccoli-funnel": "^2.0.2",
         "broccoli-merge-trees": "^4.2.0",
-        "broccoli-rollup": "^5.0.0",
+        "broccoli-rollup": "^4.1.1",
         "calculate-cache-key-for-tree": "^2.0.0",
         "chalk": "^4.0.0",
         "ember-cli-babel": "^7.26.6",
         "ember-cli-path-utils": "^1.0.0",
         "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-typescript": "^4.1.0",
+        "ember-cli-typescript": "^3.1.3",
         "ember-cli-version-checker": "^5.1.1",
         "esm": "^3.2.25",
         "git-repo-info": "^2.1.1",
@@ -2913,7 +2921,43 @@
         "silent-error": "^1.1.1"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/@ember-data/private-build-infra/node_modules/broccoli-funnel": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+      "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+      "dev": true,
+      "dependencies": {
+        "array-equal": "^1.0.0",
+        "blank-object": "^1.0.1",
+        "broccoli-plugin": "^1.3.0",
+        "debug": "^2.2.0",
+        "fast-ordered-set": "^1.0.0",
+        "fs-tree-diff": "^0.5.3",
+        "heimdalljs": "^0.2.0",
+        "minimatch": "^3.0.0",
+        "mkdirp": "^0.5.0",
+        "path-posix": "^1.0.0",
+        "rimraf": "^2.4.3",
+        "symlink-or-copy": "^1.0.0",
+        "walk-sync": "^0.3.1"
+      },
+      "engines": {
+        "node": "^4.5 || 6.* || >= 7.*"
+      }
+    },
+    "node_modules/@ember-data/private-build-infra/node_modules/broccoli-funnel/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/@ember-data/private-build-infra/node_modules/broccoli-merge-trees": {
@@ -2929,7 +2973,7 @@
         "node": "10.* || >= 12.*"
       }
     },
-    "node_modules/@ember-data/private-build-infra/node_modules/broccoli-plugin": {
+    "node_modules/@ember-data/private-build-infra/node_modules/broccoli-merge-trees/node_modules/broccoli-plugin": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
       "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
@@ -2947,112 +2991,17 @@
         "node": "10.* || >= 12.*"
       }
     },
-    "node_modules/@ember-data/private-build-infra/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+    "node_modules/@ember-data/private-build-infra/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "dependencies": {
-        "ms": "2.1.2"
+        "minimist": "^1.2.6"
       },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
-    },
-    "node_modules/@ember-data/private-build-infra/node_modules/ember-cli-typescript": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
-      "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-to-html": "^0.6.15",
-        "broccoli-stew": "^3.0.0",
-        "debug": "^4.0.0",
-        "execa": "^4.0.0",
-        "fs-extra": "^9.0.1",
-        "resolve": "^1.5.0",
-        "rsvp": "^4.8.1",
-        "semver": "^7.3.2",
-        "stagehand": "^1.0.0",
-        "walk-sync": "^2.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@ember-data/private-build-infra/node_modules/execa": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@ember-data/private-build-infra/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@ember-data/private-build-infra/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@ember-data/private-build-infra/node_modules/matcher-collection": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-      "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "minimatch": "^3.0.2"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/@ember-data/private-build-infra/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
     },
     "node_modules/@ember-data/private-build-infra/node_modules/promise-map-series": {
       "version": "0.3.0",
@@ -3063,46 +3012,23 @@
         "node": "10.* || >= 12.*"
       }
     },
-    "node_modules/@ember-data/private-build-infra/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@ember-data/private-build-infra/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
     "node_modules/@ember-data/record-data": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/record-data/-/record-data-3.28.10.tgz",
-      "integrity": "sha512-LYAAAlN6EgZFAXAzmyDlnnhQjgVnjA127y3EV1aRJR0xzjDfk5rFU2lsPM4D/ClKKBWN5WwiQRBb9ljyzCP7xw==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@ember-data/record-data/-/record-data-3.27.1.tgz",
+      "integrity": "sha512-QSY7vJIbfCCpVNhAXkGc73UiXqX7UyELq0Mc3URoVCKRYZJOCSnydPYARLgN/NM99HV0Mw1aa+KP8Nco8Z/gFg==",
       "dev": true,
       "dependencies": {
-        "@ember-data/canary-features": "3.28.10",
-        "@ember-data/private-build-infra": "3.28.10",
-        "@ember-data/store": "3.28.10",
+        "@ember-data/canary-features": "3.27.1",
+        "@ember-data/private-build-infra": "3.27.1",
+        "@ember-data/store": "3.27.1",
         "@ember/edition-utils": "^1.2.0",
+        "@ember/ordered-set": "^4.0.0",
         "ember-cli-babel": "^7.26.6",
         "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^4.1.0"
+        "ember-cli-typescript": "^4.0.0"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
+        "node": "10.* || >= 12.*"
       }
     },
     "node_modules/@ember-data/record-data/node_modules/debug": {
@@ -3242,19 +3168,19 @@
       "integrity": "sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ=="
     },
     "node_modules/@ember-data/serializer": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/serializer/-/serializer-3.28.10.tgz",
-      "integrity": "sha512-HJa5gSigSaBHd+4mmbbKUe3Y2GlfThbC+RP5hJ/K9feo1ckBhAVbkM1q523RYdvqHLV+cpDX5irt9A2WGmGjWw==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@ember-data/serializer/-/serializer-3.27.1.tgz",
+      "integrity": "sha512-kJE+kiisk1d9KQYRcRK4BFQhhsZ3n7ADlyK5eCsaNEwJm4YsfvKgjUgaC16MJddX4LG9d7QORHNJT9rWcCL9fg==",
       "dev": true,
       "dependencies": {
-        "@ember-data/private-build-infra": "3.28.10",
-        "@ember-data/store": "3.28.10",
+        "@ember-data/private-build-infra": "3.27.1",
+        "@ember-data/store": "3.27.1",
         "ember-cli-babel": "^7.26.6",
         "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^4.1.0"
+        "ember-cli-typescript": "^4.0.0"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
+        "node": "10.* || >= 12.*"
       }
     },
     "node_modules/@ember-data/serializer/node_modules/debug": {
@@ -3389,22 +3315,22 @@
       }
     },
     "node_modules/@ember-data/store": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/store/-/store-3.28.10.tgz",
-      "integrity": "sha512-GmAHKZJnBuAIfczrLKUCMGz3kWdMAfKjVgWH6jFHekWPypMMDFgiSeSotYi1l49uIgKcgzEKoV1iCYHUz2+1mA==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@ember-data/store/-/store-3.27.1.tgz",
+      "integrity": "sha512-RL9OkNBB9DtT5nkYTmGuk46hbVs2avuvSggiPJU3iuQYD3dJ8jC2XGGs3Z4FHEzAVWwlCnFiwVT03GfYbuIbUw==",
       "dev": true,
       "dependencies": {
-        "@ember-data/canary-features": "3.28.10",
-        "@ember-data/private-build-infra": "3.28.10",
-        "@ember/string": "^3.0.0",
+        "@ember-data/canary-features": "3.27.1",
+        "@ember-data/private-build-infra": "3.27.1",
+        "@ember/string": "^1.0.0",
         "@glimmer/tracking": "^1.0.4",
-        "ember-cached-decorator-polyfill": "^0.1.4",
         "ember-cli-babel": "^7.26.6",
         "ember-cli-path-utils": "^1.0.0",
-        "ember-cli-typescript": "^4.1.0"
+        "ember-cli-typescript": "^4.0.0",
+        "heimdalljs": "^0.3.0"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
+        "node": "10.* || >= 12.*"
       }
     },
     "node_modules/@ember-data/store/node_modules/debug": {
@@ -3482,6 +3408,21 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@ember-data/store/node_modules/heimdalljs": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.3.3.tgz",
+      "integrity": "sha512-xRlqDhgaXW4WccsiQlv6avDMKVN9Jk+FyMopDRPkmdf92TqfGSd2Osd/PKrK9sbM1AKcj8OpPlCzNlCWaLagCw==",
+      "dev": true,
+      "dependencies": {
+        "rsvp": "~3.2.1"
+      }
+    },
+    "node_modules/@ember-data/store/node_modules/heimdalljs/node_modules/rsvp": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+      "integrity": "sha512-Rf4YVNYpKjZ6ASAmibcwTNciQ5Co5Ztq6iZPEykHpkoflnD/K5ryE/rHehFsTm4NJj8nKDhbi3eKBWGogmNnkg==",
+      "dev": true
     },
     "node_modules/@ember-data/store/node_modules/jsonfile": {
       "version": "6.1.0",
@@ -3638,6 +3579,19 @@
         "node": "10.* || 12.* || >= 14"
       }
     },
+    "node_modules/@ember/ordered-set": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@ember/ordered-set/-/ordered-set-4.0.0.tgz",
+      "integrity": "sha512-cUCcme4R5H37HyK8w0qzdG5+lpb3XVr2RQHLyWEP4JsKI66Ob4tizoJOs8rb/XdHCv+F5WeA321hfPMi3DrZbg==",
+      "dev": true,
+      "dependencies": {
+        "ember-cli-babel": "^7.22.1",
+        "ember-compatibility-helpers": "^1.1.1"
+      },
+      "engines": {
+        "node": "10.* || 12.* || >= 14"
+      }
+    },
     "node_modules/@ember/render-modifiers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@ember/render-modifiers/-/render-modifiers-1.0.2.tgz",
@@ -3652,15 +3606,15 @@
       }
     },
     "node_modules/@ember/string": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@ember/string/-/string-3.0.0.tgz",
-      "integrity": "sha512-T+7QYDp8ItlQseNveK2lL6OsOO5wg7aNQ/M2RpO8cGwM80oZOnr/Y35HmMfu4ejFEc+F1LPegvu7LGfeJOicWA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ember/string/-/string-1.1.0.tgz",
+      "integrity": "sha512-T8UHFSO9hrkRM9+OingBmbQ69mdb8xjEXxZLCNprQX+cEJI+dyI0Nv3JAYt/0SFTT+/IQW40r004O2n/CsNnEQ==",
       "dev": true,
       "dependencies": {
-        "ember-cli-babel": "^7.26.6"
+        "ember-cli-babel": "^7.4.0"
       },
       "engines": {
-        "node": "12.* || 14.* || >= 16"
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/@ember/test-helpers": {
@@ -4645,14 +4599,10 @@
       }
     },
     "node_modules/@types/broccoli-plugin": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/broccoli-plugin/-/broccoli-plugin-3.0.0.tgz",
-      "integrity": "sha512-f+TcsARR2PovfFRKFdCX0kfH/QoM3ZVD2h1rl2mNvrKO0fq2uBNCBsTU3JanfU4COCt5cXpTfARyUsERlC8vIw==",
-      "deprecated": "This is a stub types definition. broccoli-plugin provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "broccoli-plugin": "*"
-      }
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@types/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz",
+      "integrity": "sha512-SLk4/hFc2kGvgwNFrpn2O1juxFOllcHAywvlo7VwxfExLzoz1GGJ0oIZCwj5fwSpvHw4AWpZjJ1fUvb62PDayQ==",
+      "dev": true
     },
     "node_modules/@types/chai": {
       "version": "4.3.3",
@@ -8368,41 +8318,38 @@
       }
     },
     "node_modules/broccoli-rollup": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/broccoli-rollup/-/broccoli-rollup-5.0.0.tgz",
-      "integrity": "sha512-QdMuXHwsdz/LOS8zu4HP91Sfi4ofimrOXoYP/lrPdRh7lJYD87Lfq4WzzUhGHsxMfzANIEvl/7qVHKD3cFJ4tA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/broccoli-rollup/-/broccoli-rollup-4.1.1.tgz",
+      "integrity": "sha512-hkp0dB5chiemi32t6hLe5bJvxuTOm1TU+SryFlZIs95KT9+94uj0C8w6k6CsZ2HuIdIZg6D252t4gwOlcTXrpA==",
       "dev": true,
       "dependencies": {
-        "@types/broccoli-plugin": "^3.0.0",
-        "broccoli-plugin": "^4.0.7",
+        "@types/broccoli-plugin": "^1.3.0",
+        "broccoli-plugin": "^2.0.0",
         "fs-tree-diff": "^2.0.1",
         "heimdalljs": "^0.2.6",
         "node-modules-path": "^1.0.1",
-        "rollup": "^2.50.0",
+        "rollup": "^1.12.0",
         "rollup-pluginutils": "^2.8.1",
         "symlink-or-copy": "^1.2.0",
-        "walk-sync": "^2.2.0"
+        "walk-sync": "^1.1.3"
       },
       "engines": {
-        "node": ">=12.0"
+        "node": ">=8.0"
       }
     },
     "node_modules/broccoli-rollup/node_modules/broccoli-plugin": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-      "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-2.1.0.tgz",
+      "integrity": "sha512-ElE4caljW4slapyEhSD9jU9Uayc8SoSABWdmY9SqbV8DHNxU6xg1jJsPcMm+cXOvggR3+G+OXAYQeFjWVnznaw==",
       "dev": true,
       "dependencies": {
-        "broccoli-node-api": "^1.7.0",
-        "broccoli-output-wrapper": "^3.2.5",
-        "fs-merger": "^3.2.1",
-        "promise-map-series": "^0.3.0",
-        "quick-temp": "^0.1.8",
-        "rimraf": "^3.0.2",
-        "symlink-or-copy": "^1.3.1"
+        "promise-map-series": "^0.2.1",
+        "quick-temp": "^0.1.3",
+        "rimraf": "^2.3.4",
+        "symlink-or-copy": "^1.1.8"
       },
       "engines": {
-        "node": "10.* || >= 12.*"
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/broccoli-rollup/node_modules/fs-tree-diff": {
@@ -8421,41 +8368,27 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/broccoli-rollup/node_modules/matcher-collection": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-      "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
+    "node_modules/broccoli-rollup/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
       "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "minimatch": "^3.0.2"
+        "glob": "^7.1.3"
       },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/broccoli-rollup/node_modules/promise-map-series": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-      "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-      "dev": true,
-      "engines": {
-        "node": "10.* || >= 12.*"
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/broccoli-rollup/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
+      "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
       "dev": true,
       "dependencies": {
         "@types/minimatch": "^3.0.3",
         "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
+        "matcher-collection": "^1.1.1"
       }
     },
     "node_modules/broccoli-sass-source-maps": {
@@ -11915,21 +11848,6 @@
         "node": "10.* || >= 12"
       }
     },
-    "node_modules/ember-cached-decorator-polyfill": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/ember-cached-decorator-polyfill/-/ember-cached-decorator-polyfill-0.1.4.tgz",
-      "integrity": "sha512-JOK7kBCWsTVCzmCefK4nr9BACDJk0owt9oIUaVt6Q0UtQ4XeAHmoK5kQ/YtDcxQF1ZevHQFdGhsTR3JLaHNJgA==",
-      "dev": true,
-      "dependencies": {
-        "@glimmer/tracking": "^1.0.4",
-        "ember-cache-primitive-polyfill": "^1.0.1",
-        "ember-cli-babel": "^7.21.0",
-        "ember-cli-babel-plugin-helpers": "^1.1.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12"
-      }
-    },
     "node_modules/ember-changeset": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ember-changeset/-/ember-changeset-4.1.1.tgz",
@@ -13961,20 +13879,21 @@
       }
     },
     "node_modules/ember-data": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-3.28.10.tgz",
-      "integrity": "sha512-6S8869S6o2iYWv2uMhMphX7WsAgvm2pA+qg1LMZX3UdMFq57BkrSuDBU43uxSbuwmKmGlzoNqVwVOtSsgBPiLg==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-3.27.1.tgz",
+      "integrity": "sha512-36P8+7B6Z5ZjyITFbf2Wcub/fdE2DTsLoPPZK7It488fub5s90o85XC0WlwUQPvff39us2N4pzjwmCZ8Jj/gjg==",
       "dev": true,
       "dependencies": {
-        "@ember-data/adapter": "3.28.10",
-        "@ember-data/debug": "3.28.10",
-        "@ember-data/model": "3.28.10",
-        "@ember-data/private-build-infra": "3.28.10",
-        "@ember-data/record-data": "3.28.10",
-        "@ember-data/serializer": "3.28.10",
-        "@ember-data/store": "3.28.10",
+        "@ember-data/adapter": "3.27.1",
+        "@ember-data/debug": "3.27.1",
+        "@ember-data/model": "3.27.1",
+        "@ember-data/private-build-infra": "3.27.1",
+        "@ember-data/record-data": "3.27.1",
+        "@ember-data/serializer": "3.27.1",
+        "@ember-data/store": "3.27.1",
         "@ember/edition-utils": "^1.2.0",
-        "@ember/string": "^3.0.0",
+        "@ember/ordered-set": "^4.0.0",
+        "@ember/string": "^1.0.0",
         "@glimmer/env": "^0.1.7",
         "broccoli-merge-trees": "^4.2.0",
         "ember-cli-babel": "^7.26.6",
@@ -13982,7 +13901,7 @@
         "ember-inflector": "^4.0.1"
       },
       "engines": {
-        "node": "12.* || >= 14.*"
+        "node": "10.* || >= 12.*"
       }
     },
     "node_modules/ember-data-table": {
@@ -28937,18 +28856,17 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.79.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.0.tgz",
-      "integrity": "sha512-x4KsrCgwQ7ZJPcFA/SUu6QVcYlO7uRLfLAy0DSA4NS2eG8japdbpM50ToH7z4iObodRYOJ0soneF0iaQRJ6zhA==",
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+      "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
       "dev": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/node": "*",
+        "acorn": "^7.1.0"
+      },
       "bin": {
         "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
       }
     },
     "node_modules/rollup-pluginutils": {
@@ -34243,18 +34161,18 @@
       }
     },
     "@ember-data/adapter": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-3.28.10.tgz",
-      "integrity": "sha512-/ocqzP2dPw/wTUMiE0A5YE5lUvUVLslnKCTQYLCmgKYhBaKihAiyhrug2XXHsUsi065GODuY9tpt2YO+mGiotQ==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-3.27.1.tgz",
+      "integrity": "sha512-g9JPXn2QvV47xFWbY7xRiVp4LEbE4vkVo/qu3NtrvD+MLHNmfWn6VHhx2+v5mQB0pBe8lK8nPZGoS8PM/3CMuA==",
       "dev": true,
       "requires": {
-        "@ember-data/private-build-infra": "3.28.10",
-        "@ember-data/store": "3.28.10",
+        "@ember-data/private-build-infra": "3.27.1",
+        "@ember-data/store": "3.27.1",
         "@ember/edition-utils": "^1.2.0",
-        "@ember/string": "^3.0.0",
+        "@ember/string": "^1.0.0",
         "ember-cli-babel": "^7.26.6",
         "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^4.1.0"
+        "ember-cli-typescript": "^4.0.0"
       },
       "dependencies": {
         "debug": {
@@ -34360,9 +34278,9 @@
       }
     },
     "@ember-data/canary-features": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/canary-features/-/canary-features-3.28.10.tgz",
-      "integrity": "sha512-QaRMNSzsH1XvwCKyCXlimZhVSYAcs1x42cBemaiRMg5/LDrDZKMhWbFTNomM/k+0D2a0zHsCO91FXG8m1K19qQ==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@ember-data/canary-features/-/canary-features-3.27.1.tgz",
+      "integrity": "sha512-7RLYG1W1woBu116h4bE3zfEHCV+EVVzNZcgRD3tUH9cg/EvOfXfn3naAFNnoA7TIEl2ZShRPgNNi2SjkYYy52Q==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",
@@ -34472,17 +34390,17 @@
       }
     },
     "@ember-data/debug": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/debug/-/debug-3.28.10.tgz",
-      "integrity": "sha512-smR2X8J0jycq5i3og0nFrYEEbwxjUPcXJ75tlAz9Rahqxz6U3UWAv29TKBNVUFeDQvJuOvdLzcfLK9YZ9i9bxQ==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@ember-data/debug/-/debug-3.27.1.tgz",
+      "integrity": "sha512-VWAzZFqKiheMc7Qx5yIekpdfamSBWURjNF5NKCQGGLRv7SsQe1eOjbW5iaq+gsnNr/gk4U95yLd225kUf6ubEQ==",
       "dev": true,
       "requires": {
-        "@ember-data/private-build-infra": "3.28.10",
+        "@ember-data/private-build-infra": "3.27.1",
         "@ember/edition-utils": "^1.2.0",
-        "@ember/string": "^3.0.0",
+        "@ember/string": "^1.0.0",
         "ember-cli-babel": "^7.26.6",
         "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^4.1.0"
+        "ember-cli-typescript": "^4.0.0"
       },
       "dependencies": {
         "debug": {
@@ -34588,23 +34506,22 @@
       }
     },
     "@ember-data/model": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-3.28.10.tgz",
-      "integrity": "sha512-k72fqbKjSSmDHLGr0U/kHRsFI7gamN2nMGs0Qh1c2ZPR7CLXaNUCOQnJ/itxRInTX8WO996hjMUB+IMiKqfwYQ==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-3.27.1.tgz",
+      "integrity": "sha512-GC5bf2wAad6ePCoreOj4JknJaJ62FBwR9q+/zFxADU1Ns68kyVm/Xg7KD1sDvcXEwLJebH09j9sN7LkwZaN3Og==",
       "dev": true,
       "requires": {
-        "@ember-data/canary-features": "3.28.10",
-        "@ember-data/private-build-infra": "3.28.10",
-        "@ember-data/store": "3.28.10",
+        "@ember-data/canary-features": "3.27.1",
+        "@ember-data/private-build-infra": "3.27.1",
+        "@ember-data/store": "3.27.1",
         "@ember/edition-utils": "^1.2.0",
-        "@ember/string": "^3.0.0",
-        "ember-cached-decorator-polyfill": "^0.1.4",
+        "@ember/string": "^1.0.0",
         "ember-cli-babel": "^7.26.6",
         "ember-cli-string-utils": "^1.1.0",
         "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^4.1.0",
+        "ember-cli-typescript": "^4.0.0",
         "ember-compatibility-helpers": "^1.2.0",
-        "inflection": "~1.13.1"
+        "inflection": "1.12.0"
       },
       "dependencies": {
         "debug": {
@@ -34662,6 +34579,12 @@
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
           }
+        },
+        "inflection": {
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
+          "integrity": "sha512-lRy4DxuIFWXlJU7ed8UiTJOSTqStqYdEb4CEbtXfNbkdj3nH1L+reUWiE10VWcJS2yR7tge8Z74pJjtBjNwj0w==",
+          "dev": true
         },
         "jsonfile": {
           "version": "6.1.0",
@@ -34710,28 +34633,28 @@
       }
     },
     "@ember-data/private-build-infra": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/private-build-infra/-/private-build-infra-3.28.10.tgz",
-      "integrity": "sha512-Fd9n2SOsndFOuDISkYQZsWRkif8gu0UG/1Yvloy3eOAPNLJBbGovZOFRgO4bxcPg3iHUl6THbYSLl/rXYv/Xiw==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@ember-data/private-build-infra/-/private-build-infra-3.27.1.tgz",
+      "integrity": "sha512-Cox/CRovg1gFGuO2zn64JSAezbbO1XHP+tLWDXRIiB2Oqlk3CtNxEs9K02DxMCojK4C8itFDOVpBKLYCB5MbYQ==",
       "dev": true,
       "requires": {
         "@babel/plugin-transform-block-scoping": "^7.8.3",
-        "@ember-data/canary-features": "3.28.10",
+        "@ember-data/canary-features": "3.27.1",
         "@ember/edition-utils": "^1.2.0",
         "babel-plugin-debug-macros": "^0.3.3",
         "babel-plugin-filter-imports": "^4.0.0",
         "babel6-plugin-strip-class-callcheck": "^6.0.0",
         "broccoli-debug": "^0.6.5",
         "broccoli-file-creator": "^2.1.1",
-        "broccoli-funnel": "^3.0.3",
+        "broccoli-funnel": "^2.0.2",
         "broccoli-merge-trees": "^4.2.0",
-        "broccoli-rollup": "^5.0.0",
+        "broccoli-rollup": "^4.1.1",
         "calculate-cache-key-for-tree": "^2.0.0",
         "chalk": "^4.0.0",
         "ember-cli-babel": "^7.26.6",
         "ember-cli-path-utils": "^1.0.0",
         "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-typescript": "^4.1.0",
+        "ember-cli-typescript": "^3.1.3",
         "ember-cli-version-checker": "^5.1.1",
         "esm": "^3.2.25",
         "git-repo-info": "^2.1.1",
@@ -34743,6 +34666,38 @@
         "silent-error": "^1.1.1"
       },
       "dependencies": {
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "2.7.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+              "dev": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            }
+          }
+        },
         "broccoli-merge-trees": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-4.2.0.tgz",
@@ -34751,144 +34706,56 @@
           "requires": {
             "broccoli-plugin": "^4.0.2",
             "merge-trees": "^2.0.0"
+          },
+          "dependencies": {
+            "broccoli-plugin": {
+              "version": "4.0.7",
+              "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
+              "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
+              "dev": true,
+              "requires": {
+                "broccoli-node-api": "^1.7.0",
+                "broccoli-output-wrapper": "^3.2.5",
+                "fs-merger": "^3.2.1",
+                "promise-map-series": "^0.3.0",
+                "quick-temp": "^0.1.8",
+                "rimraf": "^3.0.2",
+                "symlink-or-copy": "^1.3.1"
+              }
+            }
           }
         },
-        "broccoli-plugin": {
-          "version": "4.0.7",
-          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-          "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
+        "mkdirp": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
           "dev": true,
           "requires": {
-            "broccoli-node-api": "^1.7.0",
-            "broccoli-output-wrapper": "^3.2.5",
-            "fs-merger": "^3.2.1",
-            "promise-map-series": "^0.3.0",
-            "quick-temp": "^0.1.8",
-            "rimraf": "^3.0.2",
-            "symlink-or-copy": "^1.3.1"
+            "minimist": "^1.2.6"
           }
-        },
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ember-cli-typescript": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
-          "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
-          "dev": true,
-          "requires": {
-            "ansi-to-html": "^0.6.15",
-            "broccoli-stew": "^3.0.0",
-            "debug": "^4.0.0",
-            "execa": "^4.0.0",
-            "fs-extra": "^9.0.1",
-            "resolve": "^1.5.0",
-            "rsvp": "^4.8.1",
-            "semver": "^7.3.2",
-            "stagehand": "^1.0.0",
-            "walk-sync": "^2.2.0"
-          }
-        },
-        "execa": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.0",
-            "get-stream": "^5.0.0",
-            "human-signals": "^1.1.1",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.0",
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2",
-            "strip-final-newline": "^2.0.0"
-          }
-        },
-        "fs-extra": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-          "dev": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "matcher-collection": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-          "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "minimatch": "^3.0.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
         },
         "promise-map-series": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
           "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
           "dev": true
-        },
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-          "dev": true
-        },
-        "walk-sync": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0",
-            "minimatch": "^3.0.4"
-          }
         }
       }
     },
     "@ember-data/record-data": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/record-data/-/record-data-3.28.10.tgz",
-      "integrity": "sha512-LYAAAlN6EgZFAXAzmyDlnnhQjgVnjA127y3EV1aRJR0xzjDfk5rFU2lsPM4D/ClKKBWN5WwiQRBb9ljyzCP7xw==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@ember-data/record-data/-/record-data-3.27.1.tgz",
+      "integrity": "sha512-QSY7vJIbfCCpVNhAXkGc73UiXqX7UyELq0Mc3URoVCKRYZJOCSnydPYARLgN/NM99HV0Mw1aa+KP8Nco8Z/gFg==",
       "dev": true,
       "requires": {
-        "@ember-data/canary-features": "3.28.10",
-        "@ember-data/private-build-infra": "3.28.10",
-        "@ember-data/store": "3.28.10",
+        "@ember-data/canary-features": "3.27.1",
+        "@ember-data/private-build-infra": "3.27.1",
+        "@ember-data/store": "3.27.1",
         "@ember/edition-utils": "^1.2.0",
+        "@ember/ordered-set": "^4.0.0",
         "ember-cli-babel": "^7.26.6",
         "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^4.1.0"
+        "ember-cli-typescript": "^4.0.0"
       },
       "dependencies": {
         "debug": {
@@ -34999,16 +34866,16 @@
       "integrity": "sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ=="
     },
     "@ember-data/serializer": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/serializer/-/serializer-3.28.10.tgz",
-      "integrity": "sha512-HJa5gSigSaBHd+4mmbbKUe3Y2GlfThbC+RP5hJ/K9feo1ckBhAVbkM1q523RYdvqHLV+cpDX5irt9A2WGmGjWw==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@ember-data/serializer/-/serializer-3.27.1.tgz",
+      "integrity": "sha512-kJE+kiisk1d9KQYRcRK4BFQhhsZ3n7ADlyK5eCsaNEwJm4YsfvKgjUgaC16MJddX4LG9d7QORHNJT9rWcCL9fg==",
       "dev": true,
       "requires": {
-        "@ember-data/private-build-infra": "3.28.10",
-        "@ember-data/store": "3.28.10",
+        "@ember-data/private-build-infra": "3.27.1",
+        "@ember-data/store": "3.27.1",
         "ember-cli-babel": "^7.26.6",
         "ember-cli-test-info": "^1.0.0",
-        "ember-cli-typescript": "^4.1.0"
+        "ember-cli-typescript": "^4.0.0"
       },
       "dependencies": {
         "debug": {
@@ -35114,19 +34981,19 @@
       }
     },
     "@ember-data/store": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/store/-/store-3.28.10.tgz",
-      "integrity": "sha512-GmAHKZJnBuAIfczrLKUCMGz3kWdMAfKjVgWH6jFHekWPypMMDFgiSeSotYi1l49uIgKcgzEKoV1iCYHUz2+1mA==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@ember-data/store/-/store-3.27.1.tgz",
+      "integrity": "sha512-RL9OkNBB9DtT5nkYTmGuk46hbVs2avuvSggiPJU3iuQYD3dJ8jC2XGGs3Z4FHEzAVWwlCnFiwVT03GfYbuIbUw==",
       "dev": true,
       "requires": {
-        "@ember-data/canary-features": "3.28.10",
-        "@ember-data/private-build-infra": "3.28.10",
-        "@ember/string": "^3.0.0",
+        "@ember-data/canary-features": "3.27.1",
+        "@ember-data/private-build-infra": "3.27.1",
+        "@ember/string": "^1.0.0",
         "@glimmer/tracking": "^1.0.4",
-        "ember-cached-decorator-polyfill": "^0.1.4",
         "ember-cli-babel": "^7.26.6",
         "ember-cli-path-utils": "^1.0.0",
-        "ember-cli-typescript": "^4.1.0"
+        "ember-cli-typescript": "^4.0.0",
+        "heimdalljs": "^0.3.0"
       },
       "dependencies": {
         "debug": {
@@ -35183,6 +35050,23 @@
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
+          }
+        },
+        "heimdalljs": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.3.3.tgz",
+          "integrity": "sha512-xRlqDhgaXW4WccsiQlv6avDMKVN9Jk+FyMopDRPkmdf92TqfGSd2Osd/PKrK9sbM1AKcj8OpPlCzNlCWaLagCw==",
+          "dev": true,
+          "requires": {
+            "rsvp": "~3.2.1"
+          },
+          "dependencies": {
+            "rsvp": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+              "integrity": "sha512-Rf4YVNYpKjZ6ASAmibcwTNciQ5Co5Ztq6iZPEykHpkoflnD/K5ryE/rHehFsTm4NJj8nKDhbi3eKBWGogmNnkg==",
+              "dev": true
+            }
           }
         },
         "jsonfile": {
@@ -35313,6 +35197,16 @@
         "silent-error": "^1.1.1"
       }
     },
+    "@ember/ordered-set": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@ember/ordered-set/-/ordered-set-4.0.0.tgz",
+      "integrity": "sha512-cUCcme4R5H37HyK8w0qzdG5+lpb3XVr2RQHLyWEP4JsKI66Ob4tizoJOs8rb/XdHCv+F5WeA321hfPMi3DrZbg==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.22.1",
+        "ember-compatibility-helpers": "^1.1.1"
+      }
+    },
     "@ember/render-modifiers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@ember/render-modifiers/-/render-modifiers-1.0.2.tgz",
@@ -35324,12 +35218,12 @@
       }
     },
     "@ember/string": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@ember/string/-/string-3.0.0.tgz",
-      "integrity": "sha512-T+7QYDp8ItlQseNveK2lL6OsOO5wg7aNQ/M2RpO8cGwM80oZOnr/Y35HmMfu4ejFEc+F1LPegvu7LGfeJOicWA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ember/string/-/string-1.1.0.tgz",
+      "integrity": "sha512-T8UHFSO9hrkRM9+OingBmbQ69mdb8xjEXxZLCNprQX+cEJI+dyI0Nv3JAYt/0SFTT+/IQW40r004O2n/CsNnEQ==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^7.26.6"
+        "ember-cli-babel": "^7.4.0"
       }
     },
     "@ember/test-helpers": {
@@ -36119,13 +36013,10 @@
       }
     },
     "@types/broccoli-plugin": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/broccoli-plugin/-/broccoli-plugin-3.0.0.tgz",
-      "integrity": "sha512-f+TcsARR2PovfFRKFdCX0kfH/QoM3ZVD2h1rl2mNvrKO0fq2uBNCBsTU3JanfU4COCt5cXpTfARyUsERlC8vIw==",
-      "dev": true,
-      "requires": {
-        "broccoli-plugin": "*"
-      }
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@types/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz",
+      "integrity": "sha512-SLk4/hFc2kGvgwNFrpn2O1juxFOllcHAywvlo7VwxfExLzoz1GGJ0oIZCwj5fwSpvHw4AWpZjJ1fUvb62PDayQ==",
+      "dev": true
     },
     "@types/chai": {
       "version": "4.3.3",
@@ -39434,35 +39325,32 @@
       }
     },
     "broccoli-rollup": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/broccoli-rollup/-/broccoli-rollup-5.0.0.tgz",
-      "integrity": "sha512-QdMuXHwsdz/LOS8zu4HP91Sfi4ofimrOXoYP/lrPdRh7lJYD87Lfq4WzzUhGHsxMfzANIEvl/7qVHKD3cFJ4tA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/broccoli-rollup/-/broccoli-rollup-4.1.1.tgz",
+      "integrity": "sha512-hkp0dB5chiemi32t6hLe5bJvxuTOm1TU+SryFlZIs95KT9+94uj0C8w6k6CsZ2HuIdIZg6D252t4gwOlcTXrpA==",
       "dev": true,
       "requires": {
-        "@types/broccoli-plugin": "^3.0.0",
-        "broccoli-plugin": "^4.0.7",
+        "@types/broccoli-plugin": "^1.3.0",
+        "broccoli-plugin": "^2.0.0",
         "fs-tree-diff": "^2.0.1",
         "heimdalljs": "^0.2.6",
         "node-modules-path": "^1.0.1",
-        "rollup": "^2.50.0",
+        "rollup": "^1.12.0",
         "rollup-pluginutils": "^2.8.1",
         "symlink-or-copy": "^1.2.0",
-        "walk-sync": "^2.2.0"
+        "walk-sync": "^1.1.3"
       },
       "dependencies": {
         "broccoli-plugin": {
-          "version": "4.0.7",
-          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-          "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-2.1.0.tgz",
+          "integrity": "sha512-ElE4caljW4slapyEhSD9jU9Uayc8SoSABWdmY9SqbV8DHNxU6xg1jJsPcMm+cXOvggR3+G+OXAYQeFjWVnznaw==",
           "dev": true,
           "requires": {
-            "broccoli-node-api": "^1.7.0",
-            "broccoli-output-wrapper": "^3.2.5",
-            "fs-merger": "^3.2.1",
-            "promise-map-series": "^0.3.0",
-            "quick-temp": "^0.1.8",
-            "rimraf": "^3.0.2",
-            "symlink-or-copy": "^1.3.1"
+            "promise-map-series": "^0.2.1",
+            "quick-temp": "^0.1.3",
+            "rimraf": "^2.3.4",
+            "symlink-or-copy": "^1.1.8"
           }
         },
         "fs-tree-diff": {
@@ -39478,32 +39366,24 @@
             "symlink-or-copy": "^1.1.8"
           }
         },
-        "matcher-collection": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-          "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "dev": true,
           "requires": {
-            "@types/minimatch": "^3.0.3",
-            "minimatch": "^3.0.2"
+            "glob": "^7.1.3"
           }
         },
-        "promise-map-series": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-          "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-          "dev": true
-        },
         "walk-sync": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
+          "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
           "dev": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
             "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0",
-            "minimatch": "^3.0.4"
+            "matcher-collection": "^1.1.1"
           }
         }
       }
@@ -42271,18 +42151,6 @@
         "silent-error": "^1.1.1"
       }
     },
-    "ember-cached-decorator-polyfill": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/ember-cached-decorator-polyfill/-/ember-cached-decorator-polyfill-0.1.4.tgz",
-      "integrity": "sha512-JOK7kBCWsTVCzmCefK4nr9BACDJk0owt9oIUaVt6Q0UtQ4XeAHmoK5kQ/YtDcxQF1ZevHQFdGhsTR3JLaHNJgA==",
-      "dev": true,
-      "requires": {
-        "@glimmer/tracking": "^1.0.4",
-        "ember-cache-primitive-polyfill": "^1.0.1",
-        "ember-cli-babel": "^7.21.0",
-        "ember-cli-babel-plugin-helpers": "^1.1.1"
-      }
-    },
     "ember-changeset": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ember-changeset/-/ember-changeset-4.1.1.tgz",
@@ -43908,20 +43776,21 @@
       }
     },
     "ember-data": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-3.28.10.tgz",
-      "integrity": "sha512-6S8869S6o2iYWv2uMhMphX7WsAgvm2pA+qg1LMZX3UdMFq57BkrSuDBU43uxSbuwmKmGlzoNqVwVOtSsgBPiLg==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-3.27.1.tgz",
+      "integrity": "sha512-36P8+7B6Z5ZjyITFbf2Wcub/fdE2DTsLoPPZK7It488fub5s90o85XC0WlwUQPvff39us2N4pzjwmCZ8Jj/gjg==",
       "dev": true,
       "requires": {
-        "@ember-data/adapter": "3.28.10",
-        "@ember-data/debug": "3.28.10",
-        "@ember-data/model": "3.28.10",
-        "@ember-data/private-build-infra": "3.28.10",
-        "@ember-data/record-data": "3.28.10",
-        "@ember-data/serializer": "3.28.10",
-        "@ember-data/store": "3.28.10",
+        "@ember-data/adapter": "3.27.1",
+        "@ember-data/debug": "3.27.1",
+        "@ember-data/model": "3.27.1",
+        "@ember-data/private-build-infra": "3.27.1",
+        "@ember-data/record-data": "3.27.1",
+        "@ember-data/serializer": "3.27.1",
+        "@ember-data/store": "3.27.1",
         "@ember/edition-utils": "^1.2.0",
-        "@ember/string": "^3.0.0",
+        "@ember/ordered-set": "^4.0.0",
+        "@ember/string": "^1.0.0",
         "@glimmer/env": "^0.1.7",
         "broccoli-merge-trees": "^4.2.0",
         "ember-cli-babel": "^7.26.6",
@@ -55642,12 +55511,14 @@
       }
     },
     "rollup": {
-      "version": "2.79.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.0.tgz",
-      "integrity": "sha512-x4KsrCgwQ7ZJPcFA/SUu6QVcYlO7uRLfLAy0DSA4NS2eG8japdbpM50ToH7z4iObodRYOJ0soneF0iaQRJ6zhA==",
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+      "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
       "dev": true,
       "requires": {
-        "fsevents": "~2.3.2"
+        "@types/estree": "*",
+        "@types/node": "*",
+        "acorn": "^7.1.0"
       }
     },
     "rollup-pluginutils": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ember-cli-terser": "^4.0.2",
     "ember-concurrency": "^2.0.2",
     "ember-config-helper": "^0.1.4",
-    "ember-data": "~3.28.6",
+    "ember-data": "~3.27.1",
     "ember-drag-drop": "^0.9.0-beta.0",
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mow-registry",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "private": true,
   "description": "Small description for mow-registry goes here",
   "repository": "https://github.com/lblod/frontend-mow-registry",


### PR DESCRIPTION
This PR downgrades ember-data to 3.27.1. This project relies on non-officially supported behaviour in the domain of polymorphic relations. This behaviour was fixed/removed in ember-data 3.28.