### PR TITLE
Upgrade to ember-data 3.28.12 with fixes/modifications on how data and relationships are handled

### DIFF
--- a/app/components/add-instruction.hbs
+++ b/app/components/add-instruction.hbs
@@ -1,4 +1,4 @@
-<div class="au-o-grid__item au-u-2-5@medium">
+<div class="au-o-grid__item au-u-2-5@medium" {{did-insert this.didInsert}}>
   <div
     class="au-c-body-container au-c-action-sidebar"
     {{auto-focus ".au-c-action-sidebar__header"}}

--- a/app/components/add-instruction.js
+++ b/app/components/add-instruction.js
@@ -23,7 +23,7 @@ export default class AddInstructionComponent extends Component {
 
   @action
   async didInsert() {
-    await this.fetchData.perform();
+    this.fetchData.perform();
   }
 
   @task

--- a/app/components/add-instruction.js
+++ b/app/components/add-instruction.js
@@ -21,9 +21,9 @@ export default class AddInstructionComponent extends Component {
 
   mappingsToBeDeleted = [];
 
-  constructor(...args) {
-    super(...args);
-    this.fetchData.perform();
+  @action
+  async didInsert() {
+    await this.fetchData.perform();
   }
 
   @task

--- a/app/components/codelist-form.hbs
+++ b/app/components/codelist-form.hbs
@@ -3,7 +3,7 @@
     @codelist this.CodelistValidations
   ) as |codelist|
 }}
-  <BreadcrumbsItem as |linkClass| {{did-insert this.didInsert}}>
+  <BreadcrumbsItem as |linkClass|>
     {{#if @codelist.isNew}}
       <LinkTo
         @route="codelists-management.new"
@@ -34,7 +34,7 @@
     </AuToolbarGroup>
   </AuToolbar>
 
-  <div class="au-c-body-container au-c-body-container--scroll">
+  <div class="au-c-body-container au-c-body-container--scroll"  {{did-insert this.didInsert}}>
     <div>
         {{#let codelist.error.label as |isInvalid|}}
           <p class="au-o-box au-u-padding-bottom-none">

--- a/app/components/codelist-form.hbs
+++ b/app/components/codelist-form.hbs
@@ -3,7 +3,7 @@
     @codelist this.CodelistValidations
   ) as |codelist|
 }}
-  <BreadcrumbsItem as |linkClass|>
+  <BreadcrumbsItem as |linkClass| {{did-insert this.didInsert}}>
     {{#if @codelist.isNew}}
       <LinkTo
         @route="codelists-management.new"

--- a/app/components/codelist-form.js
+++ b/app/components/codelist-form.js
@@ -22,10 +22,10 @@ export default class CodelistFormComponent extends Component {
 
   CodelistValidations = CodelistValidations;
 
-  constructor() {
-    super(...arguments);
-    this.options = this.args.codelist.concepts;
-    this.fetchCodelistTypes.perform();
+  @action
+  async didInsert() {
+    this.options = await this.args.codelist.concepts;
+    await this.fetchCodelistTypes.perform();
   }
 
   get isSaving() {

--- a/app/components/codelist-form.js
+++ b/app/components/codelist-form.js
@@ -25,7 +25,7 @@ export default class CodelistFormComponent extends Component {
   @action
   async didInsert() {
     this.options = await this.args.codelist.concepts;
-    await this.fetchCodelistTypes.perform();
+    this.fetchCodelistTypes.perform();
   }
 
   get isSaving() {

--- a/app/components/traffic-measure-template.hbs
+++ b/app/components/traffic-measure-template.hbs
@@ -1,1 +1,3 @@
-{{this.template}}
+<span {{did-insert this.didInsert}}>
+  {{this.template}}
+</span>

--- a/app/components/traffic-measure-template.js
+++ b/app/components/traffic-measure-template.js
@@ -9,7 +9,7 @@ export default class TrafficMeasureTemplateComponent extends Component {
 
   @action
   async didInsert() {
-    await this.fetchTemplate.perform(this.args.concept);
+    this.fetchTemplate.perform(this.args.concept);
   }
   @task
   *fetchTemplate(concept) {

--- a/app/components/traffic-measure-template.js
+++ b/app/components/traffic-measure-template.js
@@ -2,14 +2,14 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { htmlSafe } from '@ember/template';
 import { task } from 'ember-concurrency';
+import { action } from '@ember/object';
 
 export default class TrafficMeasureTemplateComponent extends Component {
   @tracked template;
-  constructor() {
-    super(...arguments);
-    this.fetchTemplate.perform(this.args.concept);
-    const concept = this.args.concept;
-    console.log(concept);
+
+  @action
+  async didInsert() {
+    await this.fetchTemplate.perform(this.args.concept);
   }
   @task
   *fetchTemplate(concept) {

--- a/app/components/traffic-measure/index.hbs
+++ b/app/components/traffic-measure/index.hbs
@@ -1,4 +1,4 @@
-<div class="au-o-grid au-o-grid--flush au-o-grid--split">
+<div class="au-o-grid au-o-grid--flush au-o-grid--split" {{did-insert this.didInsert}}>
   {{!-- template-lint-disable no-inline-styles --}}
   <div class="au-o-grid__item au-u-1-2@medium">
     <div class="au-o-box au-c-body-container au-c-body-container--scroll au-c-body-container--table">

--- a/app/components/traffic-measure/index.js
+++ b/app/components/traffic-measure/index.js
@@ -29,12 +29,11 @@ export default class TrafficMeasureIndexComponent extends Component {
 
   mappingsToBeDeleted = [];
 
-  constructor(...args) {
-    super(...args);
-
-    this.trafficMeasureConcept = this.args.trafficMeasureConcept;
+  @action
+  async didInsert() {
+    this.trafficMeasureConcept = await this.args.trafficMeasureConcept;
     this.new = this.args.new;
-    this.fetchData.perform();
+    await this.fetchData.perform();
     this.inputTypes = [
       {
         value: 'text',
@@ -94,10 +93,10 @@ export default class TrafficMeasureIndexComponent extends Component {
     // Wait for data loading
     yield this.trafficMeasureConcept.relations;
     this.codeLists = yield this.codeListService.all.perform();
-
     // We assume that a measure has only one template
     const templates = yield this.trafficMeasureConcept.templates;
     this.template = yield templates.firstObject;
+    console.log('TEMPLATE', this.template);
     this.mappings = yield this.template.mappings;
     this.mappings.sortBy('id');
 

--- a/app/components/traffic-measure/index.js
+++ b/app/components/traffic-measure/index.js
@@ -29,11 +29,8 @@ export default class TrafficMeasureIndexComponent extends Component {
 
   mappingsToBeDeleted = [];
 
-  @action
-  async didInsert() {
-    this.trafficMeasureConcept = await this.args.trafficMeasureConcept;
-    this.new = this.args.new;
-    await this.fetchData.perform();
+  constructor() {
+    super(...arguments);
     this.inputTypes = [
       {
         value: 'text',
@@ -60,6 +57,13 @@ export default class TrafficMeasureIndexComponent extends Component {
       value: 'instruction',
       label: this.intl.t('utility.templateVariables.instruction'),
     };
+  }
+
+  @action
+  async didInsert() {
+    this.trafficMeasureConcept = await this.args.trafficMeasureConcept;
+    this.new = this.args.new;
+    await this.fetchData.perform();
   }
 
   get previewHtml() {
@@ -92,11 +96,14 @@ export default class TrafficMeasureIndexComponent extends Component {
   *fetchData() {
     // Wait for data loading
     yield this.trafficMeasureConcept.relations;
+
     this.codeLists = yield this.codeListService.all.perform();
+
     // We assume that a measure has only one template
     const templates = yield this.trafficMeasureConcept.templates;
     this.template = yield templates.firstObject;
     this.mappings = yield this.template.mappings;
+
     this.mappings.sortBy('id');
 
     const relations = yield this.trafficMeasureConcept.orderedRelations;
@@ -122,6 +129,7 @@ export default class TrafficMeasureIndexComponent extends Component {
         this.instructions.pushObject(instruction);
       }
     }
+
     //remove input type instruction if there are none available and reset mappings with instructions
     if (this.instructions.length != 0) {
       if (this.inputTypes.indexOf(this.instructionType) == -1) {
@@ -129,6 +137,7 @@ export default class TrafficMeasureIndexComponent extends Component {
       }
     } else if (this.instructions.length == 0) {
       if (this.inputTypes.indexOf(this.instructionType) != -1) {
+        console.log('FETCH DATA');
         this.inputTypes.splice(
           this.inputTypes.indexOf(this.instructionType),
           1

--- a/app/components/traffic-measure/index.js
+++ b/app/components/traffic-measure/index.js
@@ -61,9 +61,9 @@ export default class TrafficMeasureIndexComponent extends Component {
 
   @action
   async didInsert() {
-    this.trafficMeasureConcept = await this.args.trafficMeasureConcept;
+    this.trafficMeasureConcept = this.args.trafficMeasureConcept;
     this.new = this.args.new;
-    await this.fetchData.perform();
+    this.fetchData.perform();
   }
 
   get previewHtml() {

--- a/app/components/traffic-measure/index.js
+++ b/app/components/traffic-measure/index.js
@@ -96,7 +96,6 @@ export default class TrafficMeasureIndexComponent extends Component {
     // We assume that a measure has only one template
     const templates = yield this.trafficMeasureConcept.templates;
     this.template = yield templates.firstObject;
-    console.log('TEMPLATE', this.template);
     this.mappings = yield this.template.mappings;
     this.mappings.sortBy('id');
 

--- a/app/components/traffic-measure/instruction-entry.js
+++ b/app/components/traffic-measure/instruction-entry.js
@@ -1,13 +1,8 @@
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 
 export default class TrafficMeasureInstructionEntryComponent extends Component {
-  @tracked selectedInstruction;
-
-  constructor() {
-    super(...arguments);
-
-    this.label = this.args.sign.roadSignConceptCode
+  get label() {
+    return this.args.sign.roadSignConceptCode
       ? this.args.sign.roadSignConceptCode
       : this.args.sign.roadMarkingConceptCode
       ? this.args.sign.roadMarkingConceptCode

--- a/app/components/zonality-selector.hbs
+++ b/app/components/zonality-selector.hbs
@@ -4,6 +4,7 @@
   @options={{this.zonalities}}
   @selected={{this.selectedZonality}}
   @onChange={{this.updateZonality}} as |zonality|
+  {{did-insert this.didInsert}}
 >
   {{t (concat "utility." zonality.label)}}
 </PowerSelect>

--- a/app/components/zonality-selector.js
+++ b/app/components/zonality-selector.js
@@ -8,7 +8,7 @@ import { ZON_NON_ZONAL_ID, ZON_CONCEPT_SCHEME_ID } from '../utils/constants';
 export default class ZonalitySelectorComponent extends Component {
   @action
   async didInsert() {
-    await this.fetchZonalities.perform();
+    this.fetchZonalities.perform();
   }
 
   @tracked zonalities;

--- a/app/components/zonality-selector.js
+++ b/app/components/zonality-selector.js
@@ -6,9 +6,9 @@ import { inject as service } from '@ember/service';
 import { ZON_NON_ZONAL_ID, ZON_CONCEPT_SCHEME_ID } from '../utils/constants';
 
 export default class ZonalitySelectorComponent extends Component {
-  constructor(...args) {
-    super(...args);
-    this.fetchZonalities.perform();
+  @action
+  async didInsert() {
+    await this.fetchZonalities.perform();
   }
 
   @tracked zonalities;

--- a/app/controllers/road-sign-concepts/road-sign-concept.js
+++ b/app/controllers/road-sign-concepts/road-sign-concept.js
@@ -22,6 +22,16 @@ export default class RoadsignConceptsRoadsignConceptController extends Controlle
   @tracked relatedRoadMarkingCodeFilter = '';
   @tracked relatedTrafficLightCodeFilter = '';
 
+  @tracked isSubSign = false;
+
+  @action
+  async didInsert() {
+    this.isSubSign =
+      (await this.model.roadSignConcept.categories).filter((category) => {
+        return category.label === 'Onderbord';
+      }).length === 1;
+  }
+
   get showSidebar() {
     return (
       this.isAddingRelatedRoadSigns ||
@@ -43,14 +53,6 @@ export default class RoadsignConceptsRoadsignConceptController extends Controlle
         .toLowerCase()
         .includes(this.subSignCodeFilter.toLowerCase().trim());
     });
-  }
-
-  get isSubSign() {
-    return (
-      this.model.roadSignConcept.categories.filter((category) => {
-        return category.label === 'Onderbord';
-      }).length === 1
-    );
   }
 
   get roadMarkings() {

--- a/app/models/skos-concept.js
+++ b/app/models/skos-concept.js
@@ -3,5 +3,6 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 export default class SkosConcept extends Model {
   @attr uri;
   @attr label;
-  @belongsTo('concept-scheme', { inverse: 'concepts' }) inScheme;
+  @belongsTo('concept-scheme', { inverse: 'concepts', polymorphic: true })
+  inScheme;
 }

--- a/app/models/template.js
+++ b/app/models/template.js
@@ -4,5 +4,6 @@ export default class TemplateModel extends Model {
   @attr('string') value;
   @attr('string') annotated;
   @hasMany('mapping') mappings;
-  @belongsTo('concept', { inverse: 'templates' }) parentConcept;
+  @belongsTo('concept', { inverse: 'templates', polymorphic: true })
+  parentConcept;
 }

--- a/app/services/codelists.js
+++ b/app/services/codelists.js
@@ -16,7 +16,6 @@ export default class CodelistsService extends Service {
         include: 'concepts',
         sort: 'label',
       });
-      console.log('FETCH codelists');
       yield Promise.all(codeLists.map((codeList) => codeList.concepts));
 
       this.codeLists = codeLists;

--- a/app/services/codelists.js
+++ b/app/services/codelists.js
@@ -4,10 +4,6 @@ import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 
 export default class CodelistsService extends Service {
-  constructor(...args) {
-    super(...args);
-  }
-
   @tracked codeLists = null;
 
   @service store;
@@ -20,7 +16,7 @@ export default class CodelistsService extends Service {
         include: 'concepts',
         sort: 'label',
       });
-
+      console.log('FETCH codelists');
       yield Promise.all(codeLists.map((codeList) => codeList.concepts));
 
       this.codeLists = codeLists;

--- a/app/templates/road-marking-concepts/road-marking-concept.hbs
+++ b/app/templates/road-marking-concepts/road-marking-concept.hbs
@@ -121,7 +121,7 @@
         <AuDataTable
           @content={{
             sort-by-road-sign-code
-            @model.roadMarkingConcept.relatedRoadSignConcepts
+            (await @model.roadMarkingConcept.relatedRoadSignConcepts)
           }}
           @fields="Image Meaning Code Categories"
           @noDataMessage={{t "roadSignConcept.crud.noData"}} as |s|
@@ -204,7 +204,7 @@
         <AuDataTable
           @content={{
             sort-by-road-marking-code
-            @model.roadMarkingConcept.relatedRoadMarkingConcepts
+            (await @model.roadMarkingConcept.relatedRoadMarkingConcepts)
           }}
           @fields="Image Meaning Code Categories"
           @noDataMessage={{t "roadMarkingConcept.crud.noData"}} as |s|
@@ -287,7 +287,7 @@
         <AuDataTable
           @content={{
             sort-by-traffic-light-code
-            @model.roadMarkingConcept.relatedTrafficLightConcepts
+            (await @model.roadMarkingConcept.relatedTrafficLightConcepts)
           }}
           @fields="Image Meaning Code"
           @noDataMessage={{t "roadMarkingConcept.crud.noData"}}

--- a/app/templates/road-sign-concepts/road-sign-concept.hbs
+++ b/app/templates/road-sign-concepts/road-sign-concept.hbs
@@ -10,7 +10,7 @@
   </LinkTo>
 </BreadcrumbsItem>
 
-<div class="au-o-grid au-o-grid--flush au-o-grid--fixed">
+<div class="au-o-grid au-o-grid--flush au-o-grid--fixed" {{did-insert this.didInsert}}>
   <div
     class="au-o-grid__item {{
       if
@@ -139,7 +139,7 @@
         />
         {{#if this.isSubSign}}
           <AuDataTable
-            @content={{sort-by-road-sign-code @model.roadSignConcept.mainSigns}}
+            @content={{sort-by-road-sign-code (await @model.roadSignConcept.mainSigns)}}
             @fields="Image Meaning Code Categories"
             @noDataMessage={{t "roadSignConcept.crud.noData"}} as |s|
           >
@@ -217,7 +217,7 @@
           </AuDataTable>
         {{else}}
           <AuDataTable
-            @content={{sort-by-road-sign-code @model.roadSignConcept.subSigns}}
+            @content={{sort-by-road-sign-code (await @model.roadSignConcept.subSigns)}}
             @fields="Image Meaning Code"
             @noDataMessage={{t "roadSignConcept.crud.noData"}} as |s|
           >
@@ -289,7 +289,7 @@
         <AuDataTable
           @content={{
             sort-by-road-sign-code
-            @model.roadSignConcept.relatedRoadSignConcepts
+            (await @model.roadSignConcept.relatedRoadSignConcepts)
           }}
           @fields="Image Meaning Code Categories"
           @noDataMessage={{t "roadSignConcept.crud.noData"}} as |s|
@@ -372,7 +372,7 @@
         <AuDataTable
           @content={{
             sort-by-road-marking-code
-            @model.roadSignConcept.relatedRoadMarkingConcepts
+            (await @model.roadSignConcept.relatedRoadMarkingConcepts)
           }}
           @fields="Image Meaning Code Categories"
           @noDataMessage={{t "roadMarkingConcept.crud.noData"}}
@@ -456,7 +456,7 @@
         <AuDataTable
           @content={{
             sort-by-traffic-light-code
-            @model.roadSignConcept.relatedTrafficLightConcepts
+            (await @model.roadSignConcept.relatedTrafficLightConcepts)
           }}
           @fields="Image Meaning Code"
           @noDataMessage={{t "roadMarkingConcept.crud.noData"}}

--- a/app/templates/traffic-light-concepts/traffic-light-concept.hbs
+++ b/app/templates/traffic-light-concepts/traffic-light-concept.hbs
@@ -129,7 +129,7 @@
         <AuDataTable
           @content={{
             sort-by-road-sign-code
-            @model.trafficLightConcept.relatedRoadSignConcepts
+            (await @model.trafficLightConcept.relatedRoadSignConcepts)
           }}
           @fields="Image Meaning Code Categories"
           @noDataMessage={{t "roadSignConcept.crud.noData"}}
@@ -213,7 +213,7 @@
         <AuDataTable
           @content={{
             sort-by-road-marking-code
-            @model.trafficLightConcept.relatedRoadMarkingConcepts
+            (await @model.trafficLightConcept.relatedRoadMarkingConcepts)
           }}
           @fields="Image Meaning Code Categories"
           @noDataMessage={{t "trafficLightConcept.crud.noData"}}
@@ -297,7 +297,7 @@
         <AuDataTable
           @content={{
             sort-by-traffic-light-code
-            @model.trafficLightConcept.relatedTrafficLightConcepts
+            (await @model.trafficLightConcept.relatedTrafficLightConcepts)
           }}
           @fields="Image Meaning Code"
           @noDataMessage={{t "trafficLightConcept.crud.noData"}} as |s|

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "ember-cli-terser": "^4.0.2",
         "ember-concurrency": "^2.0.2",
         "ember-config-helper": "^0.1.4",
-        "ember-data": "~3.28.6",
+        "ember-data": "~3.28.10",
         "ember-drag-drop": "^0.9.0-beta.0",
         "ember-export-application-global": "^2.0.1",
         "ember-fetch": "^8.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "ember-cli-terser": "^4.0.2",
         "ember-concurrency": "^2.0.2",
         "ember-config-helper": "^0.1.4",
-        "ember-data": "~3.28.10",
+        "ember-data": "~3.28.12",
         "ember-drag-drop": "^0.9.0-beta.0",
         "ember-export-application-global": "^2.0.1",
         "ember-fetch": "^8.1.1",
@@ -2285,13 +2285,13 @@
       }
     },
     "node_modules/@ember-data/adapter": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-3.28.10.tgz",
-      "integrity": "sha512-/ocqzP2dPw/wTUMiE0A5YE5lUvUVLslnKCTQYLCmgKYhBaKihAiyhrug2XXHsUsi065GODuY9tpt2YO+mGiotQ==",
+      "version": "3.28.12",
+      "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-3.28.12.tgz",
+      "integrity": "sha512-pG7ITjLnYcKFZ5XrQB2kUn2mf6vwxzocXOOmCtRSS2oNVp+iYBMqNOUk6I2v5WgjwzSSePzWuGdlcOYn/KPweg==",
       "dev": true,
       "dependencies": {
-        "@ember-data/private-build-infra": "3.28.10",
-        "@ember-data/store": "3.28.10",
+        "@ember-data/private-build-infra": "3.28.12",
+        "@ember-data/store": "3.28.12",
         "@ember/edition-utils": "^1.2.0",
         "@ember/string": "^3.0.0",
         "ember-cli-babel": "^7.26.6",
@@ -2434,9 +2434,9 @@
       }
     },
     "node_modules/@ember-data/canary-features": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/canary-features/-/canary-features-3.28.10.tgz",
-      "integrity": "sha512-QaRMNSzsH1XvwCKyCXlimZhVSYAcs1x42cBemaiRMg5/LDrDZKMhWbFTNomM/k+0D2a0zHsCO91FXG8m1K19qQ==",
+      "version": "3.28.12",
+      "resolved": "https://registry.npmjs.org/@ember-data/canary-features/-/canary-features-3.28.12.tgz",
+      "integrity": "sha512-+1ymzYYCX5hc/zHv/OjEPUoEP9J/cZRiC1VWvIWm1aAZXm+th1G3wtu9+BWYVVRhX3V3rNgP2f9ePR6wgSI5LQ==",
       "dev": true,
       "dependencies": {
         "ember-cli-babel": "^7.26.6",
@@ -2578,12 +2578,12 @@
       }
     },
     "node_modules/@ember-data/debug": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/debug/-/debug-3.28.10.tgz",
-      "integrity": "sha512-smR2X8J0jycq5i3og0nFrYEEbwxjUPcXJ75tlAz9Rahqxz6U3UWAv29TKBNVUFeDQvJuOvdLzcfLK9YZ9i9bxQ==",
+      "version": "3.28.12",
+      "resolved": "https://registry.npmjs.org/@ember-data/debug/-/debug-3.28.12.tgz",
+      "integrity": "sha512-uxBqJUMD6hxie6CazFlZ8Kca1Pi34sTKs2UmJaa3MviQ67mE+XVPoVe5Q8RFpA5aIGGWsS6SNgMMIjvuR36vUw==",
       "dev": true,
       "dependencies": {
-        "@ember-data/private-build-infra": "3.28.10",
+        "@ember-data/private-build-infra": "3.28.12",
         "@ember/edition-utils": "^1.2.0",
         "@ember/string": "^3.0.0",
         "ember-cli-babel": "^7.26.6",
@@ -2726,14 +2726,14 @@
       }
     },
     "node_modules/@ember-data/model": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-3.28.10.tgz",
-      "integrity": "sha512-k72fqbKjSSmDHLGr0U/kHRsFI7gamN2nMGs0Qh1c2ZPR7CLXaNUCOQnJ/itxRInTX8WO996hjMUB+IMiKqfwYQ==",
+      "version": "3.28.12",
+      "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-3.28.12.tgz",
+      "integrity": "sha512-tv1kPqJMAq37zbn/h3Vg6Y6aaWybXdqw0Z3KnOy8wcbi5qHKdhPbozVP7gp+uUyle8addiFZ85ckJMUe0COWAw==",
       "dev": true,
       "dependencies": {
-        "@ember-data/canary-features": "3.28.10",
-        "@ember-data/private-build-infra": "3.28.10",
-        "@ember-data/store": "3.28.10",
+        "@ember-data/canary-features": "3.28.12",
+        "@ember-data/private-build-infra": "3.28.12",
+        "@ember-data/store": "3.28.12",
         "@ember/edition-utils": "^1.2.0",
         "@ember/string": "^3.0.0",
         "ember-cached-decorator-polyfill": "^0.1.4",
@@ -2880,13 +2880,13 @@
       }
     },
     "node_modules/@ember-data/private-build-infra": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/private-build-infra/-/private-build-infra-3.28.10.tgz",
-      "integrity": "sha512-Fd9n2SOsndFOuDISkYQZsWRkif8gu0UG/1Yvloy3eOAPNLJBbGovZOFRgO4bxcPg3iHUl6THbYSLl/rXYv/Xiw==",
+      "version": "3.28.12",
+      "resolved": "https://registry.npmjs.org/@ember-data/private-build-infra/-/private-build-infra-3.28.12.tgz",
+      "integrity": "sha512-Nn1ipcOcIvkS3cXjSrvey4obNjI56JpCjfMQTHrLj1m2lhYbZmiEuulbLs3Mn5y5EOZ6d5HJNK7fbhZRLoh3tQ==",
       "dev": true,
       "dependencies": {
         "@babel/plugin-transform-block-scoping": "^7.8.3",
-        "@ember-data/canary-features": "3.28.10",
+        "@ember-data/canary-features": "3.28.12",
         "@ember/edition-utils": "^1.2.0",
         "babel-plugin-debug-macros": "^0.3.3",
         "babel-plugin-filter-imports": "^4.0.0",
@@ -3088,14 +3088,14 @@
       }
     },
     "node_modules/@ember-data/record-data": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/record-data/-/record-data-3.28.10.tgz",
-      "integrity": "sha512-LYAAAlN6EgZFAXAzmyDlnnhQjgVnjA127y3EV1aRJR0xzjDfk5rFU2lsPM4D/ClKKBWN5WwiQRBb9ljyzCP7xw==",
+      "version": "3.28.12",
+      "resolved": "https://registry.npmjs.org/@ember-data/record-data/-/record-data-3.28.12.tgz",
+      "integrity": "sha512-BUhabJqdgeh2kjKgCSn+K/D4lZww7jIFiATmmC5ecXJPPI3YSTAnYzGfxOdqd6F37DTkAwDJpdPR8OcOyTfmPg==",
       "dev": true,
       "dependencies": {
-        "@ember-data/canary-features": "3.28.10",
-        "@ember-data/private-build-infra": "3.28.10",
-        "@ember-data/store": "3.28.10",
+        "@ember-data/canary-features": "3.28.12",
+        "@ember-data/private-build-infra": "3.28.12",
+        "@ember-data/store": "3.28.12",
         "@ember/edition-utils": "^1.2.0",
         "ember-cli-babel": "^7.26.6",
         "ember-cli-test-info": "^1.0.0",
@@ -3242,13 +3242,13 @@
       "integrity": "sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ=="
     },
     "node_modules/@ember-data/serializer": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/serializer/-/serializer-3.28.10.tgz",
-      "integrity": "sha512-HJa5gSigSaBHd+4mmbbKUe3Y2GlfThbC+RP5hJ/K9feo1ckBhAVbkM1q523RYdvqHLV+cpDX5irt9A2WGmGjWw==",
+      "version": "3.28.12",
+      "resolved": "https://registry.npmjs.org/@ember-data/serializer/-/serializer-3.28.12.tgz",
+      "integrity": "sha512-q6FjqL2VYmmcVdTLhENoBTpayhCnCCyWc/FPsuBO6knOuCd4vDlSK+y0BotSZ/Tadjmi6qjYrff7hpXbvnR/FQ==",
       "dev": true,
       "dependencies": {
-        "@ember-data/private-build-infra": "3.28.10",
-        "@ember-data/store": "3.28.10",
+        "@ember-data/private-build-infra": "3.28.12",
+        "@ember-data/store": "3.28.12",
         "ember-cli-babel": "^7.26.6",
         "ember-cli-test-info": "^1.0.0",
         "ember-cli-typescript": "^4.1.0"
@@ -3389,13 +3389,13 @@
       }
     },
     "node_modules/@ember-data/store": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/store/-/store-3.28.10.tgz",
-      "integrity": "sha512-GmAHKZJnBuAIfczrLKUCMGz3kWdMAfKjVgWH6jFHekWPypMMDFgiSeSotYi1l49uIgKcgzEKoV1iCYHUz2+1mA==",
+      "version": "3.28.12",
+      "resolved": "https://registry.npmjs.org/@ember-data/store/-/store-3.28.12.tgz",
+      "integrity": "sha512-y1XmmWIW/vDJsNGu14QfsZzggktqip2lGmQI6gTZacRYl7reSMZHnM9veifhRT3uZHTxcRy7nhGMsBB5QUxeeQ==",
       "dev": true,
       "dependencies": {
-        "@ember-data/canary-features": "3.28.10",
-        "@ember-data/private-build-infra": "3.28.10",
+        "@ember-data/canary-features": "3.28.12",
+        "@ember-data/private-build-infra": "3.28.12",
         "@ember/string": "^3.0.0",
         "@glimmer/tracking": "^1.0.4",
         "ember-cached-decorator-polyfill": "^0.1.4",
@@ -7053,6 +7053,16 @@
       },
       "funding": {
         "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bl": {
@@ -13961,18 +13971,18 @@
       }
     },
     "node_modules/ember-data": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-3.28.10.tgz",
-      "integrity": "sha512-6S8869S6o2iYWv2uMhMphX7WsAgvm2pA+qg1LMZX3UdMFq57BkrSuDBU43uxSbuwmKmGlzoNqVwVOtSsgBPiLg==",
+      "version": "3.28.12",
+      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-3.28.12.tgz",
+      "integrity": "sha512-eVVhYf45WjLpq2j9jIFxlrh3DG8um2tuzVMlhCGz1l6mIocT6TOW2NTcS5Ue2Dz7VDd3DeBtgfzvV6DIdouHug==",
       "dev": true,
       "dependencies": {
-        "@ember-data/adapter": "3.28.10",
-        "@ember-data/debug": "3.28.10",
-        "@ember-data/model": "3.28.10",
-        "@ember-data/private-build-infra": "3.28.10",
-        "@ember-data/record-data": "3.28.10",
-        "@ember-data/serializer": "3.28.10",
-        "@ember-data/store": "3.28.10",
+        "@ember-data/adapter": "3.28.12",
+        "@ember-data/debug": "3.28.12",
+        "@ember-data/model": "3.28.12",
+        "@ember-data/private-build-infra": "3.28.12",
+        "@ember-data/record-data": "3.28.12",
+        "@ember-data/serializer": "3.28.12",
+        "@ember-data/store": "3.28.12",
         "@ember/edition-utils": "^1.2.0",
         "@ember/string": "^3.0.0",
         "@glimmer/env": "^0.1.7",
@@ -20677,6 +20687,13 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -21271,6 +21288,20 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -24124,6 +24155,13 @@
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
+    },
+    "node_modules/nan": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
@@ -32165,6 +32203,25 @@
         "fsevents": "^1.2.7"
       }
     },
+    "node_modules/watchpack-chokidar2/node_modules/fsevents": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "deprecated": "fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
+      },
+      "engines": {
+        "node": ">= 4.0"
+      }
+    },
     "node_modules/watchpack-chokidar2/node_modules/glob-parent": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -34243,13 +34300,13 @@
       }
     },
     "@ember-data/adapter": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-3.28.10.tgz",
-      "integrity": "sha512-/ocqzP2dPw/wTUMiE0A5YE5lUvUVLslnKCTQYLCmgKYhBaKihAiyhrug2XXHsUsi065GODuY9tpt2YO+mGiotQ==",
+      "version": "3.28.12",
+      "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-3.28.12.tgz",
+      "integrity": "sha512-pG7ITjLnYcKFZ5XrQB2kUn2mf6vwxzocXOOmCtRSS2oNVp+iYBMqNOUk6I2v5WgjwzSSePzWuGdlcOYn/KPweg==",
       "dev": true,
       "requires": {
-        "@ember-data/private-build-infra": "3.28.10",
-        "@ember-data/store": "3.28.10",
+        "@ember-data/private-build-infra": "3.28.12",
+        "@ember-data/store": "3.28.12",
         "@ember/edition-utils": "^1.2.0",
         "@ember/string": "^3.0.0",
         "ember-cli-babel": "^7.26.6",
@@ -34360,9 +34417,9 @@
       }
     },
     "@ember-data/canary-features": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/canary-features/-/canary-features-3.28.10.tgz",
-      "integrity": "sha512-QaRMNSzsH1XvwCKyCXlimZhVSYAcs1x42cBemaiRMg5/LDrDZKMhWbFTNomM/k+0D2a0zHsCO91FXG8m1K19qQ==",
+      "version": "3.28.12",
+      "resolved": "https://registry.npmjs.org/@ember-data/canary-features/-/canary-features-3.28.12.tgz",
+      "integrity": "sha512-+1ymzYYCX5hc/zHv/OjEPUoEP9J/cZRiC1VWvIWm1aAZXm+th1G3wtu9+BWYVVRhX3V3rNgP2f9ePR6wgSI5LQ==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",
@@ -34472,12 +34529,12 @@
       }
     },
     "@ember-data/debug": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/debug/-/debug-3.28.10.tgz",
-      "integrity": "sha512-smR2X8J0jycq5i3og0nFrYEEbwxjUPcXJ75tlAz9Rahqxz6U3UWAv29TKBNVUFeDQvJuOvdLzcfLK9YZ9i9bxQ==",
+      "version": "3.28.12",
+      "resolved": "https://registry.npmjs.org/@ember-data/debug/-/debug-3.28.12.tgz",
+      "integrity": "sha512-uxBqJUMD6hxie6CazFlZ8Kca1Pi34sTKs2UmJaa3MviQ67mE+XVPoVe5Q8RFpA5aIGGWsS6SNgMMIjvuR36vUw==",
       "dev": true,
       "requires": {
-        "@ember-data/private-build-infra": "3.28.10",
+        "@ember-data/private-build-infra": "3.28.12",
         "@ember/edition-utils": "^1.2.0",
         "@ember/string": "^3.0.0",
         "ember-cli-babel": "^7.26.6",
@@ -34588,14 +34645,14 @@
       }
     },
     "@ember-data/model": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-3.28.10.tgz",
-      "integrity": "sha512-k72fqbKjSSmDHLGr0U/kHRsFI7gamN2nMGs0Qh1c2ZPR7CLXaNUCOQnJ/itxRInTX8WO996hjMUB+IMiKqfwYQ==",
+      "version": "3.28.12",
+      "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-3.28.12.tgz",
+      "integrity": "sha512-tv1kPqJMAq37zbn/h3Vg6Y6aaWybXdqw0Z3KnOy8wcbi5qHKdhPbozVP7gp+uUyle8addiFZ85ckJMUe0COWAw==",
       "dev": true,
       "requires": {
-        "@ember-data/canary-features": "3.28.10",
-        "@ember-data/private-build-infra": "3.28.10",
-        "@ember-data/store": "3.28.10",
+        "@ember-data/canary-features": "3.28.12",
+        "@ember-data/private-build-infra": "3.28.12",
+        "@ember-data/store": "3.28.12",
         "@ember/edition-utils": "^1.2.0",
         "@ember/string": "^3.0.0",
         "ember-cached-decorator-polyfill": "^0.1.4",
@@ -34710,13 +34767,13 @@
       }
     },
     "@ember-data/private-build-infra": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/private-build-infra/-/private-build-infra-3.28.10.tgz",
-      "integrity": "sha512-Fd9n2SOsndFOuDISkYQZsWRkif8gu0UG/1Yvloy3eOAPNLJBbGovZOFRgO4bxcPg3iHUl6THbYSLl/rXYv/Xiw==",
+      "version": "3.28.12",
+      "resolved": "https://registry.npmjs.org/@ember-data/private-build-infra/-/private-build-infra-3.28.12.tgz",
+      "integrity": "sha512-Nn1ipcOcIvkS3cXjSrvey4obNjI56JpCjfMQTHrLj1m2lhYbZmiEuulbLs3Mn5y5EOZ6d5HJNK7fbhZRLoh3tQ==",
       "dev": true,
       "requires": {
         "@babel/plugin-transform-block-scoping": "^7.8.3",
-        "@ember-data/canary-features": "3.28.10",
+        "@ember-data/canary-features": "3.28.12",
         "@ember/edition-utils": "^1.2.0",
         "babel-plugin-debug-macros": "^0.3.3",
         "babel-plugin-filter-imports": "^4.0.0",
@@ -34877,14 +34934,14 @@
       }
     },
     "@ember-data/record-data": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/record-data/-/record-data-3.28.10.tgz",
-      "integrity": "sha512-LYAAAlN6EgZFAXAzmyDlnnhQjgVnjA127y3EV1aRJR0xzjDfk5rFU2lsPM4D/ClKKBWN5WwiQRBb9ljyzCP7xw==",
+      "version": "3.28.12",
+      "resolved": "https://registry.npmjs.org/@ember-data/record-data/-/record-data-3.28.12.tgz",
+      "integrity": "sha512-BUhabJqdgeh2kjKgCSn+K/D4lZww7jIFiATmmC5ecXJPPI3YSTAnYzGfxOdqd6F37DTkAwDJpdPR8OcOyTfmPg==",
       "dev": true,
       "requires": {
-        "@ember-data/canary-features": "3.28.10",
-        "@ember-data/private-build-infra": "3.28.10",
-        "@ember-data/store": "3.28.10",
+        "@ember-data/canary-features": "3.28.12",
+        "@ember-data/private-build-infra": "3.28.12",
+        "@ember-data/store": "3.28.12",
         "@ember/edition-utils": "^1.2.0",
         "ember-cli-babel": "^7.26.6",
         "ember-cli-test-info": "^1.0.0",
@@ -34999,13 +35056,13 @@
       "integrity": "sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ=="
     },
     "@ember-data/serializer": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/serializer/-/serializer-3.28.10.tgz",
-      "integrity": "sha512-HJa5gSigSaBHd+4mmbbKUe3Y2GlfThbC+RP5hJ/K9feo1ckBhAVbkM1q523RYdvqHLV+cpDX5irt9A2WGmGjWw==",
+      "version": "3.28.12",
+      "resolved": "https://registry.npmjs.org/@ember-data/serializer/-/serializer-3.28.12.tgz",
+      "integrity": "sha512-q6FjqL2VYmmcVdTLhENoBTpayhCnCCyWc/FPsuBO6knOuCd4vDlSK+y0BotSZ/Tadjmi6qjYrff7hpXbvnR/FQ==",
       "dev": true,
       "requires": {
-        "@ember-data/private-build-infra": "3.28.10",
-        "@ember-data/store": "3.28.10",
+        "@ember-data/private-build-infra": "3.28.12",
+        "@ember-data/store": "3.28.12",
         "ember-cli-babel": "^7.26.6",
         "ember-cli-test-info": "^1.0.0",
         "ember-cli-typescript": "^4.1.0"
@@ -35114,13 +35171,13 @@
       }
     },
     "@ember-data/store": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/@ember-data/store/-/store-3.28.10.tgz",
-      "integrity": "sha512-GmAHKZJnBuAIfczrLKUCMGz3kWdMAfKjVgWH6jFHekWPypMMDFgiSeSotYi1l49uIgKcgzEKoV1iCYHUz2+1mA==",
+      "version": "3.28.12",
+      "resolved": "https://registry.npmjs.org/@ember-data/store/-/store-3.28.12.tgz",
+      "integrity": "sha512-y1XmmWIW/vDJsNGu14QfsZzggktqip2lGmQI6gTZacRYl7reSMZHnM9veifhRT3uZHTxcRy7nhGMsBB5QUxeeQ==",
       "dev": true,
       "requires": {
-        "@ember-data/canary-features": "3.28.10",
-        "@ember-data/private-build-infra": "3.28.10",
+        "@ember-data/canary-features": "3.28.12",
+        "@ember-data/private-build-infra": "3.28.12",
         "@ember/string": "^3.0.0",
         "@glimmer/tracking": "^1.0.4",
         "ember-cached-decorator-polyfill": "^0.1.4",
@@ -38250,6 +38307,16 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.3.0.tgz",
       "integrity": "sha512-nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "4.1.0",
@@ -43908,18 +43975,18 @@
       }
     },
     "ember-data": {
-      "version": "3.28.10",
-      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-3.28.10.tgz",
-      "integrity": "sha512-6S8869S6o2iYWv2uMhMphX7WsAgvm2pA+qg1LMZX3UdMFq57BkrSuDBU43uxSbuwmKmGlzoNqVwVOtSsgBPiLg==",
+      "version": "3.28.12",
+      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-3.28.12.tgz",
+      "integrity": "sha512-eVVhYf45WjLpq2j9jIFxlrh3DG8um2tuzVMlhCGz1l6mIocT6TOW2NTcS5Ue2Dz7VDd3DeBtgfzvV6DIdouHug==",
       "dev": true,
       "requires": {
-        "@ember-data/adapter": "3.28.10",
-        "@ember-data/debug": "3.28.10",
-        "@ember-data/model": "3.28.10",
-        "@ember-data/private-build-infra": "3.28.10",
-        "@ember-data/record-data": "3.28.10",
-        "@ember-data/serializer": "3.28.10",
-        "@ember-data/store": "3.28.10",
+        "@ember-data/adapter": "3.28.12",
+        "@ember-data/debug": "3.28.12",
+        "@ember-data/model": "3.28.12",
+        "@ember-data/private-build-infra": "3.28.12",
+        "@ember-data/record-data": "3.28.12",
+        "@ember-data/serializer": "3.28.12",
+        "@ember-data/store": "3.28.12",
         "@ember/edition-utils": "^1.2.0",
         "@ember/string": "^3.0.0",
         "@glimmer/env": "^0.1.7",
@@ -49308,6 +49375,13 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -49802,6 +49876,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -52103,6 +52184,13 @@
           }
         }
       }
+    },
+    "nan": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
+      "dev": true,
+      "optional": true
     },
     "nanoid": {
       "version": "3.3.4",
@@ -58248,6 +58336,17 @@
             "path-is-absolute": "^1.0.0",
             "readdirp": "^2.2.1",
             "upath": "^1.1.1"
+          }
+        },
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
           }
         },
         "glob-parent": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "ember-named-blocks-polyfill": "^0.2.4",
         "ember-page-title": "^6.2.2",
         "ember-power-select": "6.0.1",
+        "ember-promise-helpers": "^2.0.0",
         "ember-qunit": "^5.1.5",
         "ember-resolver": "^8.0.3",
         "ember-simple-auth": "^3.1.0",
@@ -17839,6 +17840,19 @@
       },
       "engines": {
         "node": "8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-promise-helpers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ember-promise-helpers/-/ember-promise-helpers-2.0.0.tgz",
+      "integrity": "sha512-ZQlzSRjCdDgGBlXHtk+LKmxOlXWKalBBZrmYlr2X/kqNf7vaVUnlKQD1T+sRzwnsZZTQwL5PKfLmSWF3hFD69g==",
+      "dev": true,
+      "dependencies": {
+        "ember-cli-babel": "^7.26.6",
+        "ember-cli-htmlbars": "^5.7.1"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
       }
     },
     "node_modules/ember-qunit": {
@@ -47114,6 +47128,16 @@
             "minimatch": "^3.0.4"
           }
         }
+      }
+    },
+    "ember-promise-helpers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ember-promise-helpers/-/ember-promise-helpers-2.0.0.tgz",
+      "integrity": "sha512-ZQlzSRjCdDgGBlXHtk+LKmxOlXWKalBBZrmYlr2X/kqNf7vaVUnlKQD1T+sRzwnsZZTQwL5PKfLmSWF3hFD69g==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.26.6",
+        "ember-cli-htmlbars": "^5.7.1"
       }
     },
     "ember-qunit": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "ember-named-blocks-polyfill": "^0.2.4",
     "ember-page-title": "^6.2.2",
     "ember-power-select": "6.0.1",
+    "ember-promise-helpers": "^2.0.0",
     "ember-qunit": "^5.1.5",
     "ember-resolver": "^8.0.3",
     "ember-simple-auth": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ember-cli-terser": "^4.0.2",
     "ember-concurrency": "^2.0.2",
     "ember-config-helper": "^0.1.4",
-    "ember-data": "~3.28.10",
+    "ember-data": "~3.28.12",
     "ember-drag-drop": "^0.9.0-beta.0",
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.1.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ember-cli-terser": "^4.0.2",
     "ember-concurrency": "^2.0.2",
     "ember-config-helper": "^0.1.4",
-    "ember-data": "~3.28.6",
+    "ember-data": "~3.28.10",
     "ember-drag-drop": "^0.9.0-beta.0",
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^8.1.1",


### PR DESCRIPTION
This draft PR includes an upgrade to ember-data 3.28.12 and additional fixes/modifications on how data/relationships are handled.

Ember-data 3.28 deprecated/removed multiple behaviours that this project relies on, mostly on the idea on how relationships are handled. E.g. array methods on PromiseManyArrays which are open for deprecation. As of ember-data 3.28 its also become impossible to call toArray() and filter() methods on unresolved data.

This PR includes the following fixes:
- Loading of resources is moved from constructors to did-insert hooks. This allows us to properly await relations and data.
- The ember-promise-helpers package is used to ensure relations are completely loaded before passing them to helpers.

