### PR TITLE
Update zonality-selector to set zonality if resource does not have any

### DIFF
--- a/app/components/zonality-selector.js
+++ b/app/components/zonality-selector.js
@@ -30,6 +30,7 @@ export default class ZonalitySelectorComponent extends Component {
       this.selectedZonality = this.zonalities.find(
         (zonality) => zonality.id == ZON_NON_ZONAL_ID
       );
+      this.args.concept.zonality = this.selectedZonality;
     }
   }
 


### PR DESCRIPTION
This ensures that if a model instance has no zonality, it gets the NON_ZONAL zonality by default.