### PR TITLE
[UI] Improve user feedback in forms

### DIFF
--- a/app/components/image-input.hbs
+++ b/app/components/image-input.hbs
@@ -28,6 +28,9 @@
   class="au-u-3-5 au-u-4-5@small"
   {{on "input" this.setImageUrl}}
 />
+{{#if this.showUrlError}}
+  <AuHelpText @size="small" @error={{true}}>{{t 'image-input.invalid-url'}}</AuHelpText>
+{{/if}}
 {{#if @error}}
   <AuHelpText @error={{true}}>
     {{t "utility.field-required"}}

--- a/app/components/image-input.hbs
+++ b/app/components/image-input.hbs
@@ -7,8 +7,6 @@
     alt={{t "image-input.preview-alt"}}
     class="image-preview"
   />
-{{else}}
-
 {{/if}}
 <AuHelpText @size="small" @skin="tertiary">{{t "image-input.helptext"}}</AuHelpText>
 <FileUploader

--- a/app/components/image-input.hbs
+++ b/app/components/image-input.hbs
@@ -9,23 +9,27 @@
   />
 {{/if}}
 <AuHelpText @size="small" @skin="tertiary">{{t "image-input.helptext"}}</AuHelpText>
-<FileUploader
-  @accept={{"image/jpeg,image/jpg,image/png,image/svg+xml"}}
-  @onFileSet={{this.setImageUpload}}
-/>
-<span>
-  {{t "utility.or"}}
-</span>
-<AuInput
-  @error={{@error}}
-  id="image-url"
-  required="required"
-  type="text"
-  placeholder={{t "image-input.url-placeholder"}}
-  @value={{this.url}}
-  class="au-u-3-5 au-u-4-5@small"
-  {{on "input" this.setImageUrl}}
-/>
+
+{{!-- because of AU bug @medium is part of wrap instead of no-wrap --}}
+<div class="flex au-u-flex--wrap@medium au-u-flex--no-wrap full-width">
+  <FileUploader
+    @accept={{"image/jpeg,image/jpg,image/png,image/svg+xml"}}
+    @onFileSet={{this.setImageUpload}}
+  />
+  <div class="au-u-margin-right au-u-margin-left">
+    {{t "utility.or"}}
+  </div>
+  <AuInput
+    @error={{@error}}
+    id="image-url"
+    required="required"
+    type="text"
+    placeholder={{t "image-input.url-placeholder"}}
+    @value={{this.url}}
+    class="full-width"
+    {{on "input" this.setImageUrl}}
+  />
+</div>
 {{#if this.showUrlError}}
   <AuHelpText @size="small" @error={{true}}>{{t 'image-input.invalid-url'}}</AuHelpText>
 {{/if}}

--- a/app/components/image-input.hbs
+++ b/app/components/image-input.hbs
@@ -1,5 +1,5 @@
 <AuLabel @error={{@error}} for="image-url" @required={{true}}>
-  {{t "road-sign-concept.attr.image-url"}}&nbsp;
+  {{t "image-input.image-url"}}&nbsp;
 </AuLabel>
 {{#if this.source}}
   <img

--- a/app/components/image-input.hbs
+++ b/app/components/image-input.hbs
@@ -1,0 +1,35 @@
+<AuLabel @error={{@error}} for="image-url" @required={{true}}>
+  {{t "road-sign-concept.attr.image-url"}}&nbsp;
+</AuLabel>
+{{#if this.source}}
+  <img
+    src={{this.source}}
+    alt={{t "image-input.preview-alt"}}
+    class="image-preview"
+  />
+{{else}}
+
+{{/if}}
+<AuHelpText @size="small" @skin="tertiary">{{t "image-input.helptext"}}</AuHelpText>
+<FileUploader
+  @accept={{"image/jpeg,image/jpg,image/png,image/svg+xml"}}
+  @onFileSet={{this.setImageUpload}}
+/>
+<span>
+  {{t "utility.or"}}
+</span>
+<AuInput
+  @error={{@error}}
+  id="image-url"
+  required="required"
+  type="text"
+  placeholder={{t "image-input.url-placeholder"}}
+  @value={{this.url}}
+  class="au-u-3-5 au-u-4-5@small"
+  {{on "input" this.setImageUrl}}
+/>
+{{#if @error}}
+  <AuHelpText @error={{true}}>
+    {{t "utility.field-required"}}
+  </AuHelpText>
+{{/if}}

--- a/app/components/image-input.js
+++ b/app/components/image-input.js
@@ -1,0 +1,52 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+/**
+ * @typedef {Object} Args
+ * @property {function} setImage
+ * @prop {boolean} error
+ * @prop {string} oldImage
+ */
+
+/**
+ * @extends {Component<Args>}
+ * @property {Args} args
+ */
+export default class ImageInputComponent extends Component {
+  @service fileService;
+  @tracked url;
+  @tracked file;
+
+  get source() {
+    return (
+      this.url ||
+      (this.file && URL.createObjectURL(this.file)) ||
+      this.args.oldImage
+    );
+  }
+
+  imageChanged() {
+    if (this.url !== '') {
+      this.args.setImage(this.url);
+    } else if (this.file) {
+      this.args.setImage(this.file);
+    } else {
+      this.args.setImage(this.args.oldImage);
+    }
+  }
+
+  @action
+  setImageUrl(event) {
+    this.url = event.target.value;
+    this.imageChanged();
+  }
+
+  @action
+  setImageUpload(event) {
+    this.file = event.target.files[0];
+    this.url = '';
+    this.imageChanged();
+  }
+}

--- a/app/components/image-input.js
+++ b/app/components/image-input.js
@@ -16,19 +16,32 @@ import { tracked } from '@glimmer/tracking';
  */
 export default class ImageInputComponent extends Component {
   @service fileService;
-  @tracked url;
+  @tracked url = '';
   @tracked file;
 
   get source() {
     return (
-      this.url ||
+      (this.isValidUrl && this.url) ||
       (this.file && URL.createObjectURL(this.file)) ||
       this.args.oldImage
     );
   }
 
+  get isValidUrl() {
+    try {
+      const parsedUrl = new URL(this.url);
+      return parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:';
+    } catch (_) {
+      return false;
+    }
+  }
+
+  get showUrlError() {
+    return this.url !== '' && !this.source;
+  }
+
   imageChanged() {
-    if (this.url !== '') {
+    if (this.isValidUrl) {
       this.args.setImage(this.url);
     } else if (this.file) {
       this.args.setImage(this.file);

--- a/app/components/image-upload-handler.js
+++ b/app/components/image-upload-handler.js
@@ -20,7 +20,7 @@ export default class ImageUploadHandlerComponent extends Component {
     }
   }
 
-  async saveFile() {
+  async saveImage() {
     if (this.isFileUrl) {
       return this.file;
     } else {

--- a/app/components/image-upload-handler.js
+++ b/app/components/image-upload-handler.js
@@ -10,27 +10,27 @@ import { inject as service } from '@ember/service';
  */
 export default class ImageUploadHandlerComponent extends Component {
   @service fileService;
-  file;
 
-  get isFileUrl() {
-    return typeof this.file === 'string';
+  fileData;
+
+  isFileUrl(file) {
+    return typeof file === 'string';
   }
 
   @action
   setImage(changeset, image) {
-    this.file = image;
-    if (this.isFileUrl) {
-      changeset.image = this.file;
+    if (this.isFileUrl(image)) {
+      changeset.image = image;
+      this.fileData = null;
     } else {
-      changeset.image = this.file.name;
+      this.fileData = image;
+      changeset.image = this.fileData.name;
     }
   }
 
-  async saveImage() {
-    if (this.isFileUrl) {
-      return this.file;
-    } else {
-      return await this.fileService.upload(this.file);
+  async saveImage(changeset) {
+    if (this.fileData) {
+      changeset.image = await this.fileService.upload(this.fileData);
     }
   }
 }

--- a/app/components/image-upload-handler.js
+++ b/app/components/image-upload-handler.js
@@ -1,0 +1,30 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+export default class ImageUploadHandlerComponent extends Component {
+  @service fileService;
+  file;
+
+  get isFileUrl() {
+    return typeof this.file === 'string';
+  }
+
+  @action
+  setImage(changeset, image) {
+    this.file = image;
+    if (this.isFileUrl) {
+      changeset.image = this.file;
+    } else {
+      changeset.image = this.file.name;
+    }
+  }
+
+  async saveFile() {
+    if (this.isFileUrl) {
+      return this.file;
+    } else {
+      return await this.fileService.upload(this.file);
+    }
+  }
+}

--- a/app/components/image-upload-handler.js
+++ b/app/components/image-upload-handler.js
@@ -2,6 +2,12 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
+/**
+ * A helper for uploading images, used in conjunction with `image-input.js`
+ * - If it is a local file, it is uploaded to the backend.
+ * - If it is a URL, it will not be uploaded and instead the direct link will be used.
+ *   the URL format is often used with digital asset management tools.
+ */
 export default class ImageUploadHandlerComponent extends Component {
   @service fileService;
   file;

--- a/app/components/road-marking-form.hbs
+++ b/app/components/road-marking-form.hbs
@@ -6,13 +6,13 @@
   <BreadcrumbsItem as |linkClass|>
     <LinkTo
       @route="road-marking-concepts.edit"
-      @model={{changeset.id}}
+      @model={{@roadMarkingConcept.id}}
       class={{linkClass}}
     >
       {{#if @roadMarkingConcept.isNew}}
         {{t "road-marking-concept.crud.new"}}
       {{else}}
-        {{changeset.roadMarkingConceptCode}}
+        {{@roadMarkingConcept.roadMarkingConceptCode}}
       {{/if}}
     </LinkTo>
   </BreadcrumbsItem>
@@ -38,7 +38,7 @@
             novalidate
           >
             {{#let changeset.error.image as |isInvalid|}}
-              <ImageInput @oldImage={{changeset.image}} @error={{isInvalid}} @setImage={{(fn this.setImage changeset)}} />
+              <ImageInput @oldImage={{@roadMarkingConcept.image}} @error={{isInvalid}} @setImage={{(fn this.setImage changeset)}} />
             {{/let}}
             {{#let changeset.error.roadMarkingConceptCode as |isInvalid|}}
               <AuFormRow>

--- a/app/components/road-marking-form.hbs
+++ b/app/components/road-marking-form.hbs
@@ -31,14 +31,16 @@
   <div class="au-c-body-container au-c-body-container--scroll">
     <div class="au-o-box">
       <div class="au-o-grid">
-        <div class="au-o-grid__item au-u-2-3@medium au-u-2-5@large">
+        <div class="au-o-grid__item au-u-2-3@medium">
           <form
             class="au-c-form"
             id="edit-road-marking-concept-form"
             novalidate
           >
             {{#let changeset.error.image as |isInvalid|}}
-              <ImageInput @oldImage={{@roadMarkingConcept.image}} @error={{isInvalid}} @setImage={{(fn this.setImage changeset)}} />
+              <AuFormRow>
+                <ImageInput @oldImage={{@roadMarkingConcept.image}} @error={{isInvalid}} @setImage={{(fn this.setImage changeset)}} />
+              </AuFormRow>
             {{/let}}
             {{#let changeset.error.roadMarkingConceptCode as |isInvalid|}}
               <AuFormRow>

--- a/app/components/road-marking-form.hbs
+++ b/app/components/road-marking-form.hbs
@@ -1,18 +1,18 @@
 {{#let
   (changeset
     @roadMarkingConcept this.RoadMarkingConceptValidations
-  ) as |roadMarkingConcept|
+  ) as |changeset|
 }}
   <BreadcrumbsItem as |linkClass|>
     <LinkTo
       @route="road-marking-concepts.edit"
-      @model={{roadMarkingConcept.id}}
+      @model={{changeset.id}}
       class={{linkClass}}
     >
       {{#if @roadMarkingConcept.isNew}}
         {{t "road-marking-concept.crud.new"}}
       {{else}}
-        {{roadMarkingConcept.roadMarkingConceptCode}}
+        {{changeset.roadMarkingConceptCode}}
       {{/if}}
     </LinkTo>
   </BreadcrumbsItem>
@@ -37,38 +37,11 @@
             id="edit-road-marking-concept-form"
             novalidate
           >
-            {{#let roadMarkingConcept.error.image as |isInvalid|}}
-              <p>
-                <AuLabel @error={{isInvalid}} for="image-url" @required={{true}}>
-                  {{t "road-marking-concept.attr.image-url"}}&nbsp;
-                </AuLabel>
-                <AuInput
-                  @error={{isInvalid}}
-                  id="image-url"
-                  required="required"
-                  type="text"
-                  @value={{roadMarkingConcept.image}}
-                  class="au-u-3-5 au-u-4-5@small"
-                  {{on "input" (fn this.setImageUrl roadMarkingConcept)}}
-                />
-                <span>
-                  {{t "utility.or"}}
-                </span>
-                <FileUploader
-                  @accept={{"image/jpeg,image/jpg,image/png,image/svg+xml"}}
-                  @onFileSet={{fn this.setImageUpload roadMarkingConcept}}
-                />
-                {{#if isInvalid}}
-                  <AuHelpText @error={{true}}>
-                    {{t "utility.field-required"}}
-                  </AuHelpText>
-                {{/if}}
-              </p>
+            {{#let changeset.error.image as |isInvalid|}}
+              <ImageInput @oldImage={{changeset.image}} @error={{isInvalid}} @setImage={{(fn this.setImage changeset)}} />
             {{/let}}
-            {{#let
-              roadMarkingConcept.error.roadMarkingConceptCode as |isInvalid|
-            }}
-              <p>
+            {{#let changeset.error.roadMarkingConceptCode as |isInvalid|}}
+              <AuFormRow>
                 <AuLabel @error={{isInvalid}} for="road-marking-concept-code" @required={{true}}>
                   {{t "road-marking-concept.attr.code"}}&nbsp;
                 </AuLabel>
@@ -76,12 +49,12 @@
                   @error={{isInvalid}}
                   id="road-marking-concept-code"
                   required="required"
-                  @value={{roadMarkingConcept.roadMarkingConceptCode}}
+                  @value={{changeset.roadMarkingConceptCode}}
                   {{on
                     "input"
                     (fn
                       this.setRoadMarkingConceptValue
-                      roadMarkingConcept
+                      changeset
                       "roadMarkingConceptCode"
                     )
                   }}
@@ -91,10 +64,10 @@
                     {{t "utility.field-required"}}
                   </AuHelpText>
                 {{/if}}
-              </p>
+              </AuFormRow>
             {{/let}}
-            {{#let roadMarkingConcept.error.meaning as |isInvalid|}}
-              <p>
+            {{#let changeset.error.meaning as |isInvalid|}}
+              <AuFormRow>
                 <AuLabel @error={{isInvalid}} for="meaning" @required={{true}}>
                   {{t "road-marking-concept.attr.meaning"}}&nbsp;
                 </AuLabel>
@@ -104,10 +77,10 @@
                   class="u-min-h-20"
                   id="meaning"
                   required="required"
-                  @value={{roadMarkingConcept.meaning}}
+                  @value={{changeset.meaning}}
                   {{on
                     "input"
-                    (fn this.setRoadMarkingConceptValue roadMarkingConcept "meaning")
+                    (fn this.setRoadMarkingConceptValue changeset "meaning")
                   }}
                 />
                 {{#if isInvalid}}
@@ -115,7 +88,7 @@
                     {{t "utility.field-required"}}
                   </AuHelpText>
                 {{/if}}
-              </p>
+              </AuFormRow>
             {{/let}}
           </form>
         </div>
@@ -127,9 +100,9 @@
     <Group>
       <AuButtonGroup>
         <AuButton
-          @disabled={{or roadMarkingConcept.isPristine this.isSaving}}
+          @disabled={{or changeset.isPristine this.isSaving}}
           @loading={{this.isSaving}}
-          {{on "click" (perform this.editRoadMarkingConceptTask roadMarkingConcept)}}
+          {{on "click" (perform this.editRoadMarkingConceptTask changeset)}}
         >
           {{t "utility.save"}}
         </AuButton>
@@ -143,7 +116,7 @@
         {{else}}
           <LinkTo
             @route="road-marking-concepts.road-marking-concept"
-            @model={{roadMarkingConcept.id}}
+            @model={{changeset.id}}
             class="au-c-button au-c-button--secondary"
           >
             {{t "utility.cancel"}}

--- a/app/components/road-marking-form.js
+++ b/app/components/road-marking-form.js
@@ -21,7 +21,7 @@ export default class RoadMarkingFormComponent extends ImageUploadHandlerComponen
   editRoadMarkingConceptTask = dropTask(async (changeset, event) => {
     event.preventDefault();
 
-    changeset.image = await this.saveImage();
+    await this.saveImage(changeset);
     await changeset.validate();
 
     if (changeset.isValid) {

--- a/app/components/road-sign-form.hbs
+++ b/app/components/road-sign-form.hbs
@@ -38,39 +38,10 @@
         <div class="au-o-grid__item au-u-2-3@medium au-u-2-5@large">
           <form class="au-c-form" id="edit-road-sign-concept-form" novalidate>
             {{#let changeset.error.image as |isInvalid|}}
-              <p>
-                <AuLabel
-                  @error={{isInvalid}}
-                  for="image-url"
-                  @required={{true}}
-                >
-                  {{t "road-sign-concept.attr.image-url"}}&nbsp;
-                </AuLabel>
-                <AuInput
-                  @error={{isInvalid}}
-                  id="image-url"
-                  required="required"
-                  type="text"
-                  @value={{changeset.image}}
-                  class="au-u-3-5 au-u-4-5@small"
-                  {{on "input" (fn this.setImageUrl changeset)}}
-                />
-                <span>
-                  {{t "utility.or"}}
-                </span>
-                <FileUploader
-                  @accept={{"image/jpeg,image/jpg,image/png,image/svg+xml"}}
-                  @onFileSet={{fn this.setImageUpload changeset}}
-                />
-                {{#if isInvalid}}
-                  <AuHelpText @error={{true}}>
-                    {{t "utility.field-required"}}
-                  </AuHelpText>
-                {{/if}}
-              </p>
+              <ImageInput @oldImage={{changeset.image}} @error={{isInvalid}} @setImage={{(fn this.setImage changeset)}} />
             {{/let}}
             {{#let changeset.error.roadSignConceptCode as |isInvalid|}}
-              <p>
+              <AuFormRow>
                 <AuLabel @error={{isInvalid}} for="road-sign-concept-code" @required={{true}}>
                   {{t "road-sign-concept.attr.code"}}&nbsp;
                 </AuLabel>
@@ -85,10 +56,10 @@
                     {{t "utility.field-required"}}
                   </AuHelpText>
                 {{/if}}
-              </p>
+              </AuFormRow>
             {{/let}}
             {{#let changeset.error.meaning as |isInvalid|}}
-              <p>
+              <AuFormRow>
                 <AuLabel @error={{isInvalid}} for="meaning" @required={{true}}>
                   {{t "road-sign-concept.attr.meaning"}}&nbsp;
                 </AuLabel>
@@ -105,10 +76,10 @@
                     {{t "utility.field-required"}}
                   </AuHelpText>
                 {{/if}}
-              </p>
+              </AuFormRow>
             {{/let}}
             {{#let changeset.error.categories as |isInvalid|}}
-              <p>
+              <AuFormRow>
                 <AuLabel @error={{isInvalid}} for="categories" @required={{true}}>
                   {{t "road-sign-concept.attr.categories"}}&nbsp;
                 </AuLabel>
@@ -132,14 +103,14 @@
                     {{t "utility.field-required"}}
                   </AuHelpText>
                 {{/if}}
-              </p>
+              </AuFormRow>
             {{/let}}
-            <p>
+            <AuFormRow>
               <AuLabel for="categories">
                 {{t "utility.zonality"}}&nbsp;
               </AuLabel>
               <ZonalitySelector @concept={{changeset}} />
-            </p>
+            </AuFormRow>
           </form>
         </div>
       </div>
@@ -150,7 +121,7 @@
     <Group>
       <AuButtonGroup>
         <AuButton
-          @disabled={{changeset.isPristine}}
+          @disabled={{or changeset.isPristine this.isSaving}}
           @loading={{this.isSaving}}
           {{on "click" (perform this.editRoadSignConceptTask changeset)}}
         >

--- a/app/components/road-sign-form.hbs
+++ b/app/components/road-sign-form.hbs
@@ -109,7 +109,7 @@
               <AuLabel for="categories">
                 {{t "utility.zonality"}}&nbsp;
               </AuLabel>
-              <ZonalitySelector @concept={{changeset}} />
+              <ZonalitySelector @zonality={{changeset.zonality}} @onChange={{(fn (mut changeset.zonality))}} />
             </AuFormRow>
           </form>
         </div>

--- a/app/components/road-sign-form.hbs
+++ b/app/components/road-sign-form.hbs
@@ -35,10 +35,12 @@
   <div class="au-c-body-container au-c-body-container--scroll">
     <div class="au-o-box">
       <div class="au-o-grid">
-        <div class="au-o-grid__item au-u-2-3@medium au-u-2-5@large">
+        <div class="au-o-grid__item au-u-2-3@medium">
           <form class="au-c-form" id="edit-road-sign-concept-form" novalidate>
             {{#let changeset.error.image as |isInvalid|}}
-              <ImageInput @oldImage={{@roadSignConcept.image}} @error={{isInvalid}} @setImage={{(fn this.setImage changeset)}} />
+              <AuFormRow>
+                <ImageInput @oldImage={{@roadSignConcept.image}} @error={{isInvalid}} @setImage={{(fn this.setImage changeset)}} />
+              </AuFormRow>
             {{/let}}
             {{#let changeset.error.roadSignConceptCode as |isInvalid|}}
               <AuFormRow>

--- a/app/components/road-sign-form.hbs
+++ b/app/components/road-sign-form.hbs
@@ -38,7 +38,7 @@
         <div class="au-o-grid__item au-u-2-3@medium au-u-2-5@large">
           <form class="au-c-form" id="edit-road-sign-concept-form" novalidate>
             {{#let changeset.error.image as |isInvalid|}}
-              <ImageInput @oldImage={{changeset.image}} @error={{isInvalid}} @setImage={{(fn this.setImage changeset)}} />
+              <ImageInput @oldImage={{@roadSignConcept.image}} @error={{isInvalid}} @setImage={{(fn this.setImage changeset)}} />
             {{/let}}
             {{#let changeset.error.roadSignConceptCode as |isInvalid|}}
               <AuFormRow>

--- a/app/components/road-sign-form.js
+++ b/app/components/road-sign-form.js
@@ -24,7 +24,7 @@ export default class RoadSignFormComponent extends ImageUploadHandlerComponent {
     await changeset.validate();
 
     if (changeset.isValid) {
-      changeset.image = await this.saveImage();
+      await this.saveImage(changeset);
       await changeset.save();
 
       this.router.transitionTo(

--- a/app/components/traffic-light-form.hbs
+++ b/app/components/traffic-light-form.hbs
@@ -11,10 +11,10 @@
     {{else}}
       <LinkTo
         @route="traffic-light-concepts.edit"
-        @model={{changeset.id}}
+        @model={{@trafficLightConcept.id}}
         class={{linkClass}}
       >
-        {{changeset.trafficLightConceptCode}}
+        {{@trafficLightConcept.trafficLightConceptCode}}
       </LinkTo>
     {{/if}}
 
@@ -42,7 +42,7 @@
             novalidate
           >
             {{#let changeset.error.image as |isInvalid|}}
-              <ImageInput @oldImage={{changeset.image}} @error={{isInvalid}} @setImage={{(fn this.setImage changeset)}} />
+              <ImageInput @oldImage={{@trafficLightConcept.image}} @error={{isInvalid}} @setImage={{(fn this.setImage changeset)}} />
             {{/let}}
             {{#let
               changeset.error.trafficLightConceptCode as |isInvalid|

--- a/app/components/traffic-light-form.hbs
+++ b/app/components/traffic-light-form.hbs
@@ -35,14 +35,16 @@
   <div class="au-c-body-container au-c-body-container--scroll">
     <div class="au-o-box">
       <div class="au-o-grid">
-        <div class="au-o-grid__item au-u-2-3@medium au-u-2-5@large">
+        <div class="au-o-grid__item au-u-2-3@medium">
           <form
             class="au-c-form"
             id="edit-traffic-light-concept-form"
             novalidate
           >
             {{#let changeset.error.image as |isInvalid|}}
-              <ImageInput @oldImage={{@trafficLightConcept.image}} @error={{isInvalid}} @setImage={{(fn this.setImage changeset)}} />
+              <AuFormRow>
+                <ImageInput @oldImage={{@trafficLightConcept.image}} @error={{isInvalid}} @setImage={{(fn this.setImage changeset)}} />
+              </AuFormRow>
             {{/let}}
             {{#let
               changeset.error.trafficLightConceptCode as |isInvalid|

--- a/app/components/traffic-light-form.hbs
+++ b/app/components/traffic-light-form.hbs
@@ -1,7 +1,7 @@
 {{#let
   (changeset
     @trafficLightConcept this.TrafficLightConceptValidations
-  ) as |trafficLightConcept|
+  ) as |changeset|
 }}
   <BreadcrumbsItem as |linkClass|>
     {{#if @trafficLightConcept.isNew}}
@@ -11,10 +11,10 @@
     {{else}}
       <LinkTo
         @route="traffic-light-concepts.edit"
-        @model={{trafficLightConcept.id}}
+        @model={{changeset.id}}
         class={{linkClass}}
       >
-        {{trafficLightConcept.trafficLightConceptCode}}
+        {{changeset.trafficLightConceptCode}}
       </LinkTo>
     {{/if}}
 
@@ -41,38 +41,13 @@
             id="edit-traffic-light-concept-form"
             novalidate
           >
-            {{#let trafficLightConcept.error.image as |isInvalid|}}
-              <p>
-                <AuLabel @error={{isInvalid}} for="image-url" @required={{true}}>
-                  {{t "traffic-light-concept.attr.image-url"}}&nbsp;
-                </AuLabel>
-                <AuInput
-                  @error={{isInvalid}}
-                  id="image-url"
-                  required="required"
-                  type="text"
-                  @value={{trafficLightConcept.image}}
-                  class="au-u-3-5 au-u-4-5@small"
-                  {{on "input" (fn this.setImageUrl trafficLightConcept)}}
-                />
-                <span>
-                  {{t "utility.or"}}
-                </span>
-                <FileUploader
-                  @accept={{"image/jpeg,image/jpg,image/png,image/svg+xml"}}
-                  @onFileSet={{fn this.setImageUpload trafficLightConcept}}
-                />
-                {{#if isInvalid}}
-                  <AuHelpText @error={{true}}>
-                    {{t "utility.field-required"}}
-                  </AuHelpText>
-                {{/if}}
-              </p>
+            {{#let changeset.error.image as |isInvalid|}}
+              <ImageInput @oldImage={{changeset.image}} @error={{isInvalid}} @setImage={{(fn this.setImage changeset)}} />
             {{/let}}
             {{#let
-              trafficLightConcept.error.trafficLightConceptCode as |isInvalid|
+              changeset.error.trafficLightConceptCode as |isInvalid|
             }}
-              <p>
+              <AuFormRow>
                 <AuLabel @error={{isInvalid}} for="traffic-light-concept-code" @required={{true}}>
                   {{t "traffic-light-concept.attr.code"}}&nbsp;
                 </AuLabel>
@@ -80,12 +55,12 @@
                   @error={{isInvalid}}
                   id="traffic-light-concept-code"
                   required="required"
-                  @value={{trafficLightConcept.trafficLightConceptCode}}
+                  @value={{changeset.trafficLightConceptCode}}
                   {{on
                     "input"
                     (fn
                       this.setTrafficLightConceptValue
-                      trafficLightConcept
+                      changeset
                       "trafficLightConceptCode"
                     )
                   }}
@@ -95,10 +70,10 @@
                     {{t "utility.field-required"}}
                   </AuHelpText>
                 {{/if}}
-              </p>
+              </AuFormRow>
             {{/let}}
-            {{#let trafficLightConcept.error.definition as |isInvalid|}}
-              <p>
+            {{#let changeset.error.definition as |isInvalid|}}
+              <AuFormRow>
                 <AuLabel @error={{isInvalid}} for="definition" @required={{true}}>
                   {{t "traffic-light-concept.attr.definition"}}&nbsp;
                 </AuLabel>
@@ -108,12 +83,12 @@
                   class="u-min-h-20"
                   id="definition"
                   required="required"
-                  @value={{trafficLightConcept.definition}}
+                  @value={{changeset.definition}}
                   {{on
                     "input"
                     (fn
                       this.setTrafficLightConceptValue
-                      trafficLightConcept
+                      changeset
                       "definition"
                     )
                   }}
@@ -123,10 +98,10 @@
                     {{t "utility.field-required"}}
                   </AuHelpText>
                 {{/if}}
-              </p>
+              </AuFormRow>
             {{/let}}
-            {{#let trafficLightConcept.error.meaning as |isInvalid|}}
-              <p>
+            {{#let changeset.error.meaning as |isInvalid|}}
+              <AuFormRow>
                 <AuLabel @error={{isInvalid}} for="meaning" @required={{true}}>
                   {{t "traffic-light-concept.attr.meaning"}}&nbsp;
                 </AuLabel>
@@ -136,12 +111,12 @@
                   class="u-min-h-20"
                   id="meaning"
                   required="required"
-                  @value={{trafficLightConcept.meaning}}
+                  @value={{changeset.meaning}}
                   {{on
                     "input"
                     (fn
                       this.setTrafficLightConceptValue
-                      trafficLightConcept
+                      changeset
                       "meaning"
                     )
                   }}
@@ -151,7 +126,7 @@
                     {{t "utility.field-required"}}
                   </AuHelpText>
                 {{/if}}
-              </p>
+              </AuFormRow>
             {{/let}}
           </form>
         </div>
@@ -163,10 +138,10 @@
     <Group>
       <AuButtonGroup>
         <AuButton
-          @disabled={{or trafficLightConcept.isPristine this.isSaving}}
+          @disabled={{or changeset.isPristine this.isSaving}}
           @loading={{this.isSaving}}
           form="edit-traffic-light-concept-form"
-          {{on "click" (perform this.editTrafficLightConceptTask trafficLightConcept)}}
+          {{on "click" (perform this.editTrafficLightConceptTask changeset)}}
         >
           {{t "utility.save"}}
         </AuButton>
@@ -180,7 +155,7 @@
         {{else}}
           <LinkTo
             @route="traffic-light-concepts.traffic-light-concept"
-            @model={{trafficLightConcept.id}}
+            @model={{changeset.id}}
             class="au-c-button au-c-button--secondary"
           >
             {{t "utility.cancel"}}

--- a/app/components/traffic-light-form.js
+++ b/app/components/traffic-light-form.js
@@ -29,7 +29,7 @@ export default class TrafficLightFormComponent extends ImageUploadHandlerCompone
     await changeset.validate();
 
     if (changeset.isValid) {
-      changeset.image = await this.saveImage();
+      await this.saveImage(changeset);
       await changeset.save();
 
       this.router.transitionTo(

--- a/app/components/traffic-light-form.js
+++ b/app/components/traffic-light-form.js
@@ -1,58 +1,40 @@
-import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { dropTask } from 'ember-concurrency';
 import TrafficLightConceptValidations from 'mow-registry/validations/traffic-light-concept';
+import ImageUploadHandlerComponent from './image-upload-handler';
 
-export default class TrafficLightFormComponent extends Component {
+export default class TrafficLightFormComponent extends ImageUploadHandlerComponent {
   @service router;
-  @service fileService;
 
   TrafficLightConceptValidations = TrafficLightConceptValidations;
-  file;
 
   get isSaving() {
     return this.editTrafficLightConceptTask.isRunning;
   }
 
   @action
-  setImageUrl(trafficLightConcept, event) {
-    trafficLightConcept.image = event.target.value;
-    this.file = null;
+  setTrafficLightConceptValue(changeset, attributeName, event) {
+    changeset[attributeName] = event.target.value;
   }
 
   @action
-  setImageUpload(trafficLightConcept, event) {
-    this.file = event.target.files[0];
-    trafficLightConcept.image = this.file.name;
+  setTrafficLightConceptCategory(changeset, selection) {
+    changeset.categories = selection;
   }
 
-  @action
-  setTrafficLightConceptValue(trafficLightConcept, attributeName, event) {
-    trafficLightConcept[attributeName] = event.target.value;
-  }
-
-  @action
-  setTrafficLightConceptCategory(trafficLightConcept, selection) {
-    trafficLightConcept.categories = selection;
-  }
-
-  editTrafficLightConceptTask = dropTask(async (trafficLightConcept, event) => {
+  editTrafficLightConceptTask = dropTask(async (changeset, event) => {
     event.preventDefault();
 
-    if (this.file) {
-      let fileResponse = await this.fileService.upload(this.file);
-      trafficLightConcept.image = fileResponse.downloadLink;
-    }
+    await changeset.validate();
 
-    await trafficLightConcept.validate();
-
-    if (trafficLightConcept.isValid) {
-      await trafficLightConcept.save();
+    if (changeset.isValid) {
+      changeset.image = await this.saveImage();
+      await changeset.save();
 
       this.router.transitionTo(
         'traffic-light-concepts.traffic-light-concept',
-        trafficLightConcept.id
+        changeset.id
       );
     }
   });

--- a/app/components/traffic-measure/index.hbs
+++ b/app/components/traffic-measure/index.hbs
@@ -10,7 +10,7 @@
           <AuHeading @level="4" @skin="4" class="au-u-margin-bottom-small">
             {{t "utility.zonality"}}
           </AuHeading>
-          <ZonalitySelector @concept={{@trafficMeasureConcept}} />
+          <ZonalitySelector @zonality={{@trafficMeasureConcept.zonality}} @onChange={{(fn (mut @trafficMeasureConcept.zonality))}} />
         </div>
         <div class="au-o-grid__item au-u-1-2">
           <AuHeading @level="4" @skin="4" class="au-u-margin-bottom-small">

--- a/app/components/zonality-selector.hbs
+++ b/app/components/zonality-selector.hbs
@@ -3,9 +3,9 @@
   @searchEnabled={{false}}
   @loadingMessage={{t "utility.loading"}}
   @options={{this.zonalities}}
-  @selected={{this.selectedZonality}}
-  @onChange={{this.updateZonality}} as |zonality|
-  {{did-insert this.didInsert}}
+  @selected={{@zonality}}
+  @onChange={{@onChange}} as |zonality|
+  {{did-insert this.didInsert}}  
 >
   {{t (concat "utility." zonality.label)}}
 </PowerSelect>

--- a/app/components/zonality-selector.js
+++ b/app/components/zonality-selector.js
@@ -5,6 +5,16 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { ZON_NON_ZONAL_ID, ZON_CONCEPT_SCHEME_ID } from '../utils/constants';
 
+/**
+ * @typedef {Object} Args
+ * @property {function} onChange
+ * @prop {string} zonality
+ */
+
+/**
+ * @extends {Component<Args>}
+ * @property {Args} args
+ */
 export default class ZonalitySelectorComponent extends Component {
   @action
   async didInsert() {
@@ -12,31 +22,21 @@ export default class ZonalitySelectorComponent extends Component {
   }
 
   @tracked zonalities;
-  @tracked selectedZonality;
 
   @service store;
 
   fetchZonalities = task(async () => {
-    await this.args.concept;
     const conceptScheme = await this.store.findRecord(
       'concept-scheme',
       ZON_CONCEPT_SCHEME_ID
     );
     this.zonalities = conceptScheme.concepts;
     await this.zonalities;
-    if (await this.args.concept.zonality) {
-      this.selectedZonality = this.args.concept.zonality;
-    } else {
+    if (!this.args.zonality) {
       const defaultZonality = this.zonalities.find(
         (zonality) => zonality.id == ZON_NON_ZONAL_ID
       );
-      this.updateZonality(defaultZonality);
+      this.args.onChange(defaultZonality);
     }
   });
-
-  @action
-  updateZonality(zonality) {
-    this.selectedZonality = zonality;
-    this.args.concept.zonality = this.selectedZonality;
-  }
 }

--- a/app/services/file-service.js
+++ b/app/services/file-service.js
@@ -1,6 +1,7 @@
 import Service from '@ember/service';
 import { inject as service } from '@ember/service';
 import fetch from 'fetch';
+import ENV from 'mow-registry/config/environment';
 
 export default class FileServiceService extends Service {
   @service store;
@@ -14,6 +15,13 @@ export default class FileServiceService extends Service {
     });
     const upload = await response.json();
     this.store.pushPayload('file', upload);
-    return this.store.peekRecord('file', upload.data.id);
+    let fileRecord = this.store.peekRecord('file', upload.data.id);
+    let downloadUrl = fileRecord.downloadLink;
+    // fileUrl is a relative url.
+    // `ENV.baseUrl` is needed if the frontend and backend are not the same base url
+    if (ENV.baseUrl) {
+      downloadUrl = ENV.baseUrl + downloadUrl;
+    }
+    return downloadUrl;
   }
 }

--- a/app/styles/_input-file.scss
+++ b/app/styles/_input-file.scss
@@ -13,7 +13,6 @@
 }
 
 .image-preview {
-  margin: auto;
   padding: $au-unit-tiny;
   margin-top: $au-unit-small;
   max-width: 200px;

--- a/app/styles/_input-file.scss
+++ b/app/styles/_input-file.scss
@@ -11,3 +11,13 @@
   cursor: pointer;
   opacity: 0;
 }
+
+.image-preview {
+  margin: auto;
+  padding: $au-unit-tiny;
+  margin-top: $au-unit-small;
+  max-width: 200px;
+  max-height: 200px;
+  border: .1rem solid var(--au-gray-200);
+  border-radius: var(--au-radius);
+}

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -162,6 +162,10 @@
   align-items: center;
 }
 
+.full-width {
+  width: 100%;
+}
+
 // Helptext list
 .au-c-list-help {
   margin-top: $au-unit-tiny;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -51,6 +51,7 @@
 
 
 // UTILITIES
+$au-flex-utilities-responsive: true;
 @import "ember-appuniversum/a-utilities";
 @import "u-heights";
 @import "shame";

--- a/app/templates/road-sign-concepts/road-sign-concept.hbs
+++ b/app/templates/road-sign-concepts/road-sign-concept.hbs
@@ -69,7 +69,7 @@
                 {{t "utility.zonality"}}
               </AuLabel>
               <p>
-                {{@model.roadSignConcept.zonality.label}}
+                {{t (concat "utility." @model.roadSignConcept.zonality.label)}}
               </p>
             </li>
             {{#unless this.showSidebar}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -53,6 +53,7 @@ image-input:
   helptext: Press the button to upload an image or insert a URL of an existing image
   preview-alt: A preview of the uploaded or linked image
   url-placeholder: insert a link as http(s)://...
+  image-url: Image URL
 road-sign-concept:
   name: Road Signs
   details: Road Sign details
@@ -93,7 +94,6 @@ traffic-light-concept:
   details: Traffic Light details
   attr:
     image-header: Image
-    image-url: Image URL
     meaning: Meaning
     definition: Definition
     code: Code

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -49,6 +49,10 @@ utility:
     location: location
     codelist: codelist
     instruction: instruction
+image-input:
+  helptext: Press the button to upload an image or insert a URL of an existing image
+  preview-alt: A preview of the uploaded or linked image
+  url-placeholder: insert a link as http(s)://...
 road-sign-concept:
   name: Road Signs
   details: Road Sign details

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -50,9 +50,10 @@ utility:
     codelist: codelist
     instruction: instruction
 image-input:
-  helptext: Press the button to upload an image or insert a URL of an existing image
+  helptext: Press the button to upload a new image or insert a URL of an existing image
   preview-alt: A preview of the uploaded or linked image
   url-placeholder: insert a link as http(s)://...
+  invalid-url: Only image URLs starting with http(s) are allowed
   image-url: Image URL
 road-sign-concept:
   name: Road Signs

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -52,7 +52,7 @@ utility:
 image-input:
   helptext: Press the button to upload a new image or insert a URL of an existing image
   preview-alt: A preview of the uploaded or linked image
-  url-placeholder: insert a link as http(s)://...
+  url-placeholder: http(s)://...
   invalid-url: Only image URLs starting with http(s) are allowed
   image-url: Image URL
 road-sign-concept:

--- a/translations/nl-be.yaml
+++ b/translations/nl-be.yaml
@@ -51,9 +51,10 @@ utility:
     codelist: codelijst
     instruction: instructie
 image-input:
-  helptext: Druk op de upload knop om een bestand te uploaden of plak de URL van een bestaande afbeelding
+  helptext: Druk op de upload knop om een nieuw bestand te uploaden of plak de URL van een bestaande afbeelding
   preview-alt: Een voorbeeld van het geüploade bestand of de URL
   url-placeholder: voeg een link toe in de vorm van http(s)://...
+  invalid-url: Enkel afbeeldings-URLs die beginnen met http(s) zijn toegelaten
   image-url: Afbeelding URL
 road-sign-concept:
   name: Verkeersborden

--- a/translations/nl-be.yaml
+++ b/translations/nl-be.yaml
@@ -54,6 +54,7 @@ image-input:
   helptext: Druk op de upload knop om een bestand te uploaden of plak de URL van een bestaande afbeelding
   preview-alt: Een voorbeeld van het geüploade bestand of de URL
   url-placeholder: voeg een link toe in de vorm van http(s)://...
+  image-url: Afbeelding URL
 road-sign-concept:
   name: Verkeersborden
   details: Verkeersbord details
@@ -87,7 +88,6 @@ traffic-light-concept:
   details: Verkeerslicht details
   attr:
     image-header: Afbeelding
-    image-url: Afbeelding URL
     meaning: Betekenis
     definition: Definitie
     code: Code

--- a/translations/nl-be.yaml
+++ b/translations/nl-be.yaml
@@ -53,7 +53,7 @@ utility:
 image-input:
   helptext: Druk op de upload knop om een nieuw bestand te uploaden of plak de URL van een bestaande afbeelding
   preview-alt: Een voorbeeld van het geüploade bestand of de URL
-  url-placeholder: voeg een link toe in de vorm van http(s)://...
+  url-placeholder: http(s)://...
   invalid-url: Enkel afbeeldings-URLs die beginnen met http(s) zijn toegelaten
   image-url: Afbeelding URL
 road-sign-concept:

--- a/translations/nl-be.yaml
+++ b/translations/nl-be.yaml
@@ -31,6 +31,7 @@ utility:
   delete: verwijderen
   instructions: Instructies
   description: Beschrijving
+  image-preview-alt: Een voorbeeldweergave van de geüploade of de gelinkte afbeelding
   order: Volgorde
   sign: Verkeersteken
   add-instruction: Voeg instructie toe
@@ -49,6 +50,10 @@ utility:
     location: locatie
     codelist: codelijst
     instruction: instructie
+image-input:
+  helptext: Druk op de upload knop om een bestand te uploaden of plak de URL van een bestaande afbeelding
+  preview-alt: Een voorbeeld van het geüploade bestand of de URL
+  url-placeholder: voeg een link toe in de vorm van http(s)://...
 road-sign-concept:
   name: Verkeersborden
   details: Verkeersbord details


### PR DESCRIPTION
Improves the simple forms (all forms except traffic measure) to have better user feedback. This was not connected to a specific issue.

- **Image-input component**
  - shows an image preview after uploading or pasting a URL
  - has a set logic when the URL or when the uploaded image is used when submitting (before it was not clear for the user)
  - Explanation and error messages
- **Image-upload-handler component**
  - help class for image-input
  - handles uploading of images in the same way for all forms
  -> is this a good way to bundle this logic? It can't be part of the image-input component (would break DDAU I think). 
- Use AuFormRow to follow styleguide
  -> this makes the form a bit less readable (like the zonality dropdown, should be a bit wider). I tried to fix this by using classes or even CSS, but the au-css classes just made things worse instead of better, and I'm not sure if I'd just be breaking the style guide instead
- use "changeset" as variable name where it fits. This also meant that some bugs came to the surface, which are fixed.
- change the zonality-selector to follow DDAU.
- adds translation for everything.

### Important notes
This is a PR on the hackaton branch (see #145 ). Probably the best is to wait for that one to merge before merging this one on master. 

The images are now only uploaded when the form validates. However, the images are never removed (e.g. when removing something or when editing and uploading an alternative image). There might be a service that deletes images that aren't connected to anything, but I have not found this.
It might be advisable to create an issue for this. Alternatively they could just be removed via the frontend, but as a service apparently exists, I didn't bother.
When this service is added, I would advice to add some explanation in `file-service.js` to explain that images are removed automatically by the backend stack. (might want to mention this in the issue?)
