### PR TITLE
Fixed mistake in translation to keep consistency

### DIFF
--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -176,7 +176,7 @@ traffic-measure-concept:
     no-matches: No results found
     type-to-search: Type to search
   landing-page:
-    content: Manage mobility measures.
+    content: Manage traffic measures.
     button: Go to traffic measures
 sub-sign:
   filter:


### PR DESCRIPTION
mobiliteitsmaatregelen is always translated as traffic measures except in this specific case, so I changed it. Asking for review in case I missed something as I don't speak dutch but I think this is good to merge