### PR TITLE
GN-4399: check if related road-marking or traffic-light has undefined definition

### DIFF
--- a/app/controllers/road-marking-concepts/road-marking-concept.js
+++ b/app/controllers/road-marking-concepts/road-marking-concept.js
@@ -53,7 +53,7 @@ export default class RoadmarkingConceptsRoadmarkingConceptController extends Con
 
     return this.model.allRoadMarkings.filter((roadMarking) => {
       return roadMarking.definition
-        .toLowerCase()
+        ?.toLowerCase()
         .includes(this.relatedRoadMarkingCodeFilter.toLowerCase());
     });
   }
@@ -65,7 +65,7 @@ export default class RoadmarkingConceptsRoadmarkingConceptController extends Con
 
     return this.model.allTrafficLights.filter((trafficLight) => {
       return trafficLight.definition
-        .toLowerCase()
+        ?.toLowerCase()
         .includes(this.relatedTrafficLightCodeFilter.toLowerCase());
     });
   }

--- a/app/controllers/road-sign-concepts/road-sign-concept.js
+++ b/app/controllers/road-sign-concepts/road-sign-concept.js
@@ -63,7 +63,7 @@ export default class RoadsignConceptsRoadsignConceptController extends Controlle
 
     return this.model.allRoadMarkings.filter((roadMarking) => {
       return roadMarking.definition
-        .toLowerCase()
+        ?.toLowerCase()
         .includes(this.relatedRoadMarkingCodeFilter.toLowerCase());
     });
   }
@@ -75,7 +75,7 @@ export default class RoadsignConceptsRoadsignConceptController extends Controlle
 
     return this.model.allTrafficLights.filter((trafficLight) => {
       return trafficLight.definition
-        .toLowerCase()
+        ?.toLowerCase()
         .includes(this.relatedTrafficLightCodeFilter.toLowerCase());
     });
   }

--- a/app/controllers/traffic-light-concepts/traffic-light-concept.js
+++ b/app/controllers/traffic-light-concepts/traffic-light-concept.js
@@ -40,7 +40,7 @@ export default class RoadsignConceptsRoadsignConceptController extends Controlle
 
     return this.model.allTrafficLights.filter((trafficLight) => {
       return trafficLight.definition
-        .toLowerCase()
+        ?.toLowerCase()
         .includes(this.relatedTrafficLightCodeFilter.toLowerCase());
     });
   }
@@ -52,7 +52,7 @@ export default class RoadsignConceptsRoadsignConceptController extends Controlle
 
     return this.model.allRoadMarkings.filter((roadMarking) => {
       return roadMarking.definition
-        .toLowerCase()
+        ?.toLowerCase()
         .includes(this.relatedRoadMarkingCodeFilter.toLowerCase());
     });
   }


### PR DESCRIPTION
## Overview
This PR solves an issue where an error was thrown when search for related road-markings. This turned out to be an issue of a missing nullcheck on `roadMarking.definition`. This PR also adds nullchecks to  `trafficLight.definition` to prevent a similar issue.

##### connected issues and PRs:
Jira: https://binnenland.atlassian.net/browse/GN-4399?atlOrigin=eyJpIjoiNjkyNTIzYTA4NDQwNGQwNzk5ZTMyM2ZlNjBlY2Y3MjQiLCJwIjoiaiJ9

### How to test/reproduce
- Open a road-sign/road-marking/traffic-light
- Search through the list of related road-markings, the `undefined` error should no longer be thrown. 

### Checks PR readiness
- [x] npm lint
- [x] no new deprecations