### PR TITLE
add option to edit/fill-in definitions of road-sign concepts

### DIFF
--- a/app/components/road-sign-form.hbs
+++ b/app/components/road-sign-form.hbs
@@ -52,6 +52,42 @@
                   id="road-sign-concept-code"
                   required="required"
                   @value={{changeset.roadSignConceptCode}}
+                  {{on
+                    "input"
+                    (fn
+                      this.setRoadSignConceptValue
+                      changeset
+                      "roadSignConceptCode"
+                    )
+                  }}
+                />
+                {{#if isInvalid}}
+                  <AuHelpText @error={{true}}>
+                    {{t "utility.field-required"}}
+                  </AuHelpText>
+                {{/if}}
+              </AuFormRow>
+            {{/let}}
+            {{#let changeset.error.definition as |isInvalid|}}
+              <AuFormRow>
+                <AuLabel @error={{isInvalid}} for="definition" @required={{true}}>
+                  {{t "road-sign-concept.attr.definition"}}&nbsp;
+                </AuLabel>
+                <AuTextarea
+                  @error={{isInvalid}}
+                  @width="block"
+                  class="u-min-h-20"
+                  id="definition"
+                  required="required"
+                  @value={{changeset.definition}}
+                  {{on
+                    "input"
+                    (fn
+                      this.setRoadSignConceptValue
+                      changeset
+                      "definition"
+                    )
+                  }}
                 />
                 {{#if isInvalid}}
                   <AuHelpText @error={{true}}>
@@ -72,6 +108,14 @@
                   id="meaning"
                   required="required"
                   @value={{changeset.meaning}}
+                  {{on
+                    "input"
+                    (fn
+                      this.setRoadSignConceptValue
+                      changeset
+                      "meaning"
+                    )
+                  }}
                 />
                 {{#if isInvalid}}
                   <AuHelpText @error={{true}}>

--- a/app/components/road-sign-form.ts
+++ b/app/components/road-sign-form.ts
@@ -28,6 +28,15 @@ export default class RoadSignFormComponent extends ImageUploadHandlerComponent<A
     changeset.categories = selection;
   }
 
+  @action
+  setRoadSignConceptValue(
+    changeset: BufferedChangeset,
+    attributeName: string,
+    event: InputEvent,
+  ) {
+    changeset[attributeName] = (event.target as HTMLInputElement).value;
+  }
+
   editRoadSignConceptTask = dropTask(
     async (changeset: BufferedChangeset, event: InputEvent) => {
       event.preventDefault();

--- a/app/models/road-sign-concept.ts
+++ b/app/models/road-sign-concept.ts
@@ -20,6 +20,7 @@ declare module 'ember-data/types/registries/model' {
 
 export default class RoadSignConceptModel extends ConceptModel {
   @attr declare image?: string;
+  @attr declare definition?: string;
   @attr declare meaning?: string;
   @attr declare roadSignConceptCode?: string;
 

--- a/app/templates/road-sign-concepts/road-sign-concept.hbs
+++ b/app/templates/road-sign-concepts/road-sign-concept.hbs
@@ -54,6 +54,14 @@
                 </p>
               {{/each}}
             </li>
+            <li class="au-o-grid__item au-u-1-2 au-u-1-4@medium">
+              <AuLabel>
+                {{t "road-sign-concept.attr.definition"}}
+              </AuLabel>
+              <p>
+                {{@model.roadSignConcept.definition}}
+              </p>
+            </li>
             <li class="au-o-grid__item au-u-1-2 au-u-1-6@medium">
               <AuLabel>
                 {{t "road-sign-concept.attr.meaning"}}

--- a/app/validations/road-sign-concept.ts
+++ b/app/validations/road-sign-concept.ts
@@ -5,6 +5,7 @@ import {
 
 export default {
   image: validatePresence({ presence: true, ignoreBlank: true }),
+  definition: validatePresence({ presence: true, ignoreBlank: true }),
   meaning: validatePresence({ presence: true, ignoreBlank: true }),
   roadSignConceptCode: validatePresence({ presence: true, ignoreBlank: true }),
   categories: validateLength({ min: 1 }),

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -63,6 +63,7 @@ road-sign-concept:
     image-header: Image
     image-url: Image URL
     meaning: Meaning
+    definition: Definition
     code: Code
     categories: Categories
     sub-sign: Possible subsigns

--- a/translations/nl-be.yaml
+++ b/translations/nl-be.yaml
@@ -64,6 +64,7 @@ road-sign-concept:
     image-header: Afbeelding
     image-url: Afbeelding URL
     meaning: Betekenis
+    definition: Definitie
     code: Code
     categories: Categorieën
     sub-sign: Mogelijke onderborden


### PR DESCRIPTION
## Overview
This PR adds the option for users to fill-in/edit the definition of road-sign concepts.
Specifically, it includes the following:
- Inclusion of the `definition` attribute in the `road-sign-concept` ember-data model
- Addition of a form field to the `road-sign-concept` edit page, which users can use to update the definition of a `road-sign-concept`
- Addition of the `definition` attribute to the `road-sign-concept` changeset validator.


##### connected issues and PRs:
Solves [GN-4464](https://binnenland.atlassian.net/browse/GN-4463?atlOrigin=eyJpIjoiYmExMTAxZTdiZTg5NDA4ZmI0ZDlmNmRkNTM2MjliYzUiLCJwIjoiaiJ9) partially 
Depends on https://github.com/lblod/app-mow-registry/pull/70


### Setup
- Checkout the backend PR https://github.com/lblod/app-mow-registry/pull/70
- Set-up the backend
- Proxy the frontend to your local backend

### How to test/reproduce
- Select an existing road-sign or create a new one
- Notice that it is possible to fill in a definition. The definition is a required field.
- The definition should also show up on the detail page of a road-sign. Note: a lot of road-signs will have their definition missing.

### Challenges/uncertainties
- Keeping this PR as a draft PR for now, as unsure if road-sign concepts need a `definition` attribute (they probably will).



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations