### PR TITLE
GN-4527: rework zonality-selector

### DIFF
--- a/.changeset/fresh-dancers-suffer.md
+++ b/.changeset/fresh-dancers-suffer.md
@@ -1,0 +1,5 @@
+---
+'mow-registry': patch
+---
+
+Refactor `zonality-selector` component with `ember-resources`

--- a/.changeset/gentle-monkeys-tell.md
+++ b/.changeset/gentle-monkeys-tell.md
@@ -1,0 +1,5 @@
+---
+'mow-registry': patch
+---
+
+Ensure zonality of a traffic-measure is awaited before passing it to the `zonality-selector` component

--- a/.changeset/old-games-hunt.md
+++ b/.changeset/old-games-hunt.md
@@ -1,0 +1,5 @@
+---
+'mow-registry': minor
+---
+
+Add `ember-async-data` dependency

--- a/app/components/traffic-measure/index.hbs
+++ b/app/components/traffic-measure/index.hbs
@@ -10,7 +10,9 @@
           <AuHeading @level="4" @skin="4" class="au-u-margin-bottom-small">
             {{t "utility.zonality"}}
           </AuHeading>
-          <ZonalitySelector @zonality={{@trafficMeasureConcept.zonality}} @onChange={{(fn (mut @trafficMeasureConcept.zonality))}} />
+          {{#let (load @trafficMeasureConcept.zonality) as |zonality|}}
+            <ZonalitySelector @zonality={{zonality.value}} @onChange={{(fn (mut @trafficMeasureConcept.zonality))}} />
+          {{/let}}
         </div>
         <div class="au-o-grid__item au-u-1-2">
           <AuHeading @level="4" @skin="4" class="au-u-margin-bottom-small">

--- a/app/components/zonality-selector.hbs
+++ b/app/components/zonality-selector.hbs
@@ -2,10 +2,9 @@
   @allowClear={{false}}
   @searchEnabled={{false}}
   @loadingMessage={{t "utility.loading"}}
-  @options={{this.zonalities}}
-  @selected={{@zonality}}
+  @options={{this.zonalities.value}}
+  @selected={{this.selectedZonality}}
   @onChange={{@onChange}} as |zonality|
-  {{did-insert this.didInsert}}  
 >
   {{zonality-label zonality}}
 </PowerSelect>

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "@typescript-eslint/parser": "^5.59.0",
         "broccoli-asset-rev": "^3.0.0",
         "changesets-release-it-plugin": "^0.1.1",
+        "ember-async-data": "^1.0.2",
         "ember-auto-import": "^2.4.3",
         "ember-changeset": "^4.0.0",
         "ember-changeset-validations": "^4.0.0",
@@ -3827,11 +3828,11 @@
       }
     },
     "node_modules/@embroider/addon-shim": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/@embroider/addon-shim/-/addon-shim-1.8.4.tgz",
-      "integrity": "sha512-sFhfWC0vI18KxVenmswQ/ShIvBg4juL8ubI+Q3NTSdkCTeaPQ/DIOUF6oR5DCQ8eO/TkIaw+kdG3FkTY6yNJqA==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@embroider/addon-shim/-/addon-shim-1.8.6.tgz",
+      "integrity": "sha512-siC9kP78uucEbpDcVyxjkwa76pcs5rVzDVpWO4PDc9EAXRX+pzmUuSTLAK3GztUwx7/PWhz1BenAivqdSvSgfg==",
       "dependencies": {
-        "@embroider/shared-internals": "^2.0.0",
+        "@embroider/shared-internals": "^2.2.3",
         "broccoli-funnel": "^3.0.8",
         "semver": "^7.3.8"
       },
@@ -13673,16 +13674,16 @@
       }
     },
     "node_modules/ember-async-data": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ember-async-data/-/ember-async-data-1.0.1.tgz",
-      "integrity": "sha512-R9nBxCZ9WDPMJpuGBODs8wV1PHXUbkSbrzVmL34R4aOWbx237yLBllJghQOwfJs1+D72wdzgxg/+J3DY43xz3g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ember-async-data/-/ember-async-data-1.0.2.tgz",
+      "integrity": "sha512-HCnQnnPCV5A7FADoW6/e+48PVxQ1ElatxZeJJoTb2UuklMHK8CpdAvEILVC0qtEeyIEbcG/LyOIxuHK0ja63zQ==",
       "dev": true,
       "dependencies": {
         "@ember/test-waiters": "^3.0.0",
-        "@embroider/addon-shim": "^1.8.4"
+        "@embroider/addon-shim": "^1.8.5"
       },
       "peerDependencies": {
-        "ember-source": "^4.8.4"
+        "ember-source": ">=4.8.4"
       }
     },
     "node_modules/ember-auto-import": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@typescript-eslint/parser": "^5.59.0",
     "broccoli-asset-rev": "^3.0.0",
     "changesets-release-it-plugin": "^0.1.1",
+    "ember-async-data": "^1.0.2",
     "ember-auto-import": "^2.4.3",
     "ember-changeset": "^4.0.0",
     "ember-changeset-validations": "^4.0.0",


### PR DESCRIPTION
## Overview
This PR does the following two things:
- Refactor of the `zonality-selector` component using ember-resources
- Ensure the zonality of a traffic measure is resolved (awaited) before passing it to the `zonality-selector` component.

##### connected issues and PRs:
Should solve [GN-4527](https://binnenland.atlassian.net/browse/GN-4527?atlOrigin=eyJpIjoiZjU0ZDJlZWRjYjc0NDViY2I1NzU4YmY4NTI3N2U0YzEiLCJwIjoiaiJ9)

### How to test/reproduce
- Select a traffic measure
- Notice that it is now possible to change the zonality of a traffic measure without errors
- Ensure that the zonality of a traffic measure is correctly saved

### Challenges/uncertainties
- In order to await the zonality of a traffic measure, the `ember-async-data` package is used, which is kept more up-to-date than `ember-promise-helpers`. When using `ember-promise-helpers` in this case, there were problems with reactivity.



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations