### PR TITLE
Addition of ember-modifier dependency (version 3.2.7)

### DIFF
--- a/.changeset/lovely-coins-shave.md
+++ b/.changeset/lovely-coins-shave.md
@@ -1,0 +1,5 @@
+---
+'mow-registry': patch
+---
+
+Add ember-modifier dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "ember-fetch": "^8.1.2",
         "ember-intl": "^5.7.2",
         "ember-load-initializers": "^2.1.2",
+        "ember-modifier": "^3.2.7",
         "ember-named-blocks-polyfill": "^0.2.4",
         "ember-page-title": "^8.0.0",
         "ember-power-select": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "ember-fetch": "^8.1.2",
     "ember-intl": "^5.7.2",
     "ember-load-initializers": "^2.1.2",
+    "ember-modifier": "^3.2.7",
     "ember-named-blocks-polyfill": "^0.2.4",
     "ember-page-title": "^8.0.0",
     "ember-power-select": "7.1.0",


### PR DESCRIPTION
## Overview
While this application defines and uses a modifier (`yasgui`), the `ember-modifier` was never explicitly added and only installed as a transitive dependency. This PR ensures that `ember-modifier` 3.2.7 is installed as a direct dependency.