### PR TITLE
Fix website url in footer

### DIFF
--- a/.changeset/shiny-socks-doubt.md
+++ b/.changeset/shiny-socks-doubt.md
@@ -1,0 +1,5 @@
+---
+'mow-registry': patch
+---
+
+Fix website URL in footer

--- a/app/templates/login.hbs
+++ b/app/templates/login.hbs
@@ -10,7 +10,7 @@
     <img sizes="50vw" src="assets/images/header-1600.jpg" srcset={{srcSet}} alt="laptop met daarop het vlaanderen logo.">
   </AuContentHeader>
   {{/let}}
-  
+
     <main id="content">
       <div class="au-o-region-large">
         <div class="au-o-layout">
@@ -26,7 +26,7 @@
     </main>
     <AuMainFooter>
       <AuHeading @level="3" @skin="4">
-        roadsigns.lblod.info is een officiële website van de Vlaamse overheid
+        register.mobiliteit.vlaanderen.be is een officiële website van de Vlaamse overheid
       </AuHeading>
       <AuContent @skin="small">
         <p>Uitgegeven door <a class="au-c-link" href="https://www.vlaanderen.be/organisaties/administratieve-diensten-van-de-vlaamse-overheid/beleidsdomein-kanselarij-en-bestuur/agentschap-binnenlands-bestuur">Agentschap Binnenlands Bestuur</a></p>


### PR DESCRIPTION
## Overview
This PR ensures that the correct URL (register.mobiliteit.vlaanderen.be) is used in the footer of this application.