### PR TITLE
GN-4398: fill-in missing translations

### DIFF
--- a/.changeset/flat-wasps-switch.md
+++ b/.changeset/flat-wasps-switch.md
@@ -1,0 +1,5 @@
+---
+'mow-registry': patch
+---
+
+Enable no-bare-strings template-lint rule

--- a/.changeset/small-shirts-press.md
+++ b/.changeset/small-shirts-press.md
@@ -1,0 +1,5 @@
+---
+'mow-registry': patch
+---
+
+Fill-in missing translations

--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -2,4 +2,7 @@
 
 module.exports = {
   extends: 'recommended',
+  rules: {
+    'no-bare-strings': true,
+  },
 };

--- a/app/components/codelist-form.hbs
+++ b/app/components/codelist-form.hbs
@@ -38,7 +38,12 @@
     <div>
         {{#let codelist.error.label as |isInvalid|}}
           <p class="au-o-box au-u-padding-bottom-none">
-            <AuLabel @error={{isInvalid}} for="label" @required={{true}}>
+            <AuLabel
+              @error={{isInvalid}}
+              for="label"
+              @required={{true}}
+              @requiredLabel={{t "utility.required"}}
+            >
               {{t "codelist.attr.label"}}&nbsp;
             </AuLabel>
             <AuInput

--- a/app/components/image-input.hbs
+++ b/app/components/image-input.hbs
@@ -1,4 +1,4 @@
-<AuLabel @error={{@error}} for="image-url" @required={{true}}>
+<AuLabel @error={{@error}} for="image-url" @required={{true}} @requiredLabel={{t "utility.required"}}>
   {{t "image-input.image-url"}}&nbsp;
 </AuLabel>
 {{#if this.source}}

--- a/app/components/road-marking-form.hbs
+++ b/app/components/road-marking-form.hbs
@@ -44,7 +44,7 @@
             {{/let}}
             {{#let changeset.error.roadMarkingConceptCode as |isInvalid|}}
               <AuFormRow>
-                <AuLabel @error={{isInvalid}} for="road-marking-concept-code" @required={{true}}>
+                <AuLabel @error={{isInvalid}} for="road-marking-concept-code" @required={{true}} @requiredLabel={{t "utility.required"}}>
                   {{t "road-marking-concept.attr.code"}}&nbsp;
                 </AuLabel>
                 <AuInput
@@ -70,7 +70,7 @@
             {{/let}}
             {{#let changeset.error.definition as |isInvalid|}}
               <AuFormRow>
-                <AuLabel @error={{isInvalid}} for="definition" @required={{true}}>
+                <AuLabel @error={{isInvalid}} for="definition" @required={{true}} @requiredLabel={{t "utility.required"}}>
                   {{t "road-marking-concept.attr.definition"}}&nbsp;
                 </AuLabel>
                 <AuTextarea
@@ -98,7 +98,7 @@
             {{/let}}
             {{#let changeset.error.meaning as |isInvalid|}}
               <AuFormRow>
-                <AuLabel @error={{isInvalid}} for="meaning" @required={{true}}>
+                <AuLabel @error={{isInvalid}} for="meaning" @required={{true}} @requiredLabel={{t "utility.required"}}>
                   {{t "road-marking-concept.attr.meaning"}}&nbsp;
                 </AuLabel>
                 <AuTextarea

--- a/app/components/road-sign-form.hbs
+++ b/app/components/road-sign-form.hbs
@@ -44,7 +44,7 @@
             {{/let}}
             {{#let changeset.error.roadSignConceptCode as |isInvalid|}}
               <AuFormRow>
-                <AuLabel @error={{isInvalid}} for="road-sign-concept-code" @required={{true}}>
+                <AuLabel @error={{isInvalid}} for="road-sign-concept-code" @required={{true}} @requiredLabel={{t "utility.required"}}>
                   {{t "road-sign-concept.attr.code"}}&nbsp;
                 </AuLabel>
                 <AuInput
@@ -62,7 +62,7 @@
             {{/let}}
             {{#let changeset.error.meaning as |isInvalid|}}
               <AuFormRow>
-                <AuLabel @error={{isInvalid}} for="meaning" @required={{true}}>
+                <AuLabel @error={{isInvalid}} for="meaning" @required={{true}} @requiredLabel={{t "utility.required"}}>
                   {{t "road-sign-concept.attr.meaning"}}&nbsp;
                 </AuLabel>
                 <AuTextarea
@@ -82,13 +82,15 @@
             {{/let}}
             {{#let changeset.error.categories as |isInvalid|}}
               <AuFormRow>
-                <AuLabel @error={{isInvalid}} for="categories" @required={{true}}>
+                <AuLabel @error={{isInvalid}} for="categories" @required={{true}} @requiredLabel={{t "utility.required"}}>
                   {{t "road-sign-concept.attr.categories"}}&nbsp;
                 </AuLabel>
                 <div class={{if isInvalid "ember-power-select--error"}}>
                   <PowerSelectMultiple
                     @allowClear={{true}}
+                    @placeholder={{t "utility.search-placeholder"}}
                     @searchEnabled={{true}}
+                    @searchMessage={{t "utility.search-placeholder"}}
                     @noMatchesMessage={{t "road-sign-concept.crud.no-data"}}
                     @searchField="label"
                     @options={{@categories}}

--- a/app/components/search-tables/traffic-measure.hbs
+++ b/app/components/search-tables/traffic-measure.hbs
@@ -14,7 +14,7 @@
     <header.Sortable
       @field="label"
       @currentSorting={{this.sort}}
-      @label="Name"
+      @label={{t "traffic-measure-concept.attr.name"}}
     />
     <th>
       {{t "traffic-measure-concept.attr.sign"}}

--- a/app/components/traffic-light-form.hbs
+++ b/app/components/traffic-light-form.hbs
@@ -50,7 +50,7 @@
               changeset.error.trafficLightConceptCode as |isInvalid|
             }}
               <AuFormRow>
-                <AuLabel @error={{isInvalid}} for="traffic-light-concept-code" @required={{true}}>
+                <AuLabel @error={{isInvalid}} for="traffic-light-concept-code" @required={{true}} @requiredLabel={{t "utility.required"}}>
                   {{t "traffic-light-concept.attr.code"}}&nbsp;
                 </AuLabel>
                 <AuInput
@@ -76,7 +76,7 @@
             {{/let}}
             {{#let changeset.error.definition as |isInvalid|}}
               <AuFormRow>
-                <AuLabel @error={{isInvalid}} for="definition" @required={{true}}>
+                <AuLabel @error={{isInvalid}} for="definition" @required={{true}} @requiredLabel={{t "utility.required"}}>
                   {{t "traffic-light-concept.attr.definition"}}&nbsp;
                 </AuLabel>
                 <AuTextarea
@@ -104,7 +104,7 @@
             {{/let}}
             {{#let changeset.error.meaning as |isInvalid|}}
               <AuFormRow>
-                <AuLabel @error={{isInvalid}} for="meaning" @required={{true}}>
+                <AuLabel @error={{isInvalid}} for="meaning" @required={{true}} @requiredLabel={{t "utility.required"}}>
                   {{t "traffic-light-concept.attr.meaning"}}&nbsp;
                 </AuLabel>
                 <AuTextarea

--- a/app/components/traffic-measure/add-sign.hbs
+++ b/app/components/traffic-measure/add-sign.hbs
@@ -3,8 +3,9 @@
     <PowerSelect
       @loadingMessage={{t "utility.loading"}}
       @noMatchesMessage={{t "traffic-measure-concept.crud.no-matches"}}
-      @placeholder={{t "traffic-measure-concept.crud.type-to-search"}}
+      @placeholder={{t "utility.search-placeholder"}}
       @searchEnabled={{true}}
+      @searchMessage={{t "utility.search-placeholder"}}
       @allowClear={{@allowClear}}
       @disabled={{@disabled}}
       @search={{perform this.search}}

--- a/app/templates/login.hbs
+++ b/app/templates/login.hbs
@@ -1,13 +1,15 @@
-{{!-- template-lint-disable no-bare-strings --}}
 <AuBodyContainer @scroll={{true}} itemprop="mainContentOfPage">
   {{#let (concat
     "assets/images/header-320.jpg" " 320w,"
     "assets/images/header-1024.jpg" " 1024w,"
     "assets/images/header-1600.jpg" " 1600w"
   ) as |srcSet|}}
-    <AuContentHeader @titlePartOne="Vlaanderen" @titlePartTwo="is lokaal bestuur">
+    <AuContentHeader
+      @titlePartOne={{t "login-page.header.title.part-one"}}
+      @titlePartTwo={{t "login-page.header.title.part-two"}}
+    >
       {{!-- template-lint-disable require-valid-alt-text --}}
-    <img sizes="50vw" src="assets/images/header-1600.jpg" srcset={{srcSet}} alt="laptop met daarop het vlaanderen logo.">
+    <img sizes="50vw" src="assets/images/header-1600.jpg" srcset={{srcSet}} alt={{t "login-page.header.image-alt"}}>
   </AuContentHeader>
   {{/let}}
 
@@ -26,10 +28,10 @@
     </main>
     <AuMainFooter>
       <AuHeading @level="3" @skin="4">
-        register.mobiliteit.vlaanderen.be is een officiële website van de Vlaamse overheid
+        {{t "login-page.footer.heading"}}
       </AuHeading>
       <AuContent @skin="small">
-        <p>Uitgegeven door <a class="au-c-link" href="https://www.vlaanderen.be/organisaties/administratieve-diensten-van-de-vlaamse-overheid/beleidsdomein-kanselarij-en-bestuur/agentschap-binnenlands-bestuur">Agentschap Binnenlands Bestuur</a></p>
+        <p>{{t "login-page.footer.published-by"}} <a class="au-c-link" href="https://www.vlaanderen.be/organisaties/administratieve-diensten-van-de-vlaamse-overheid/beleidsdomein-kanselarij-en-bestuur/agentschap-binnenlands-bestuur">{{t "login-page.footer.abb"}}</a></p>
       </AuContent>
     </AuMainFooter>
 </AuBodyContainer>

--- a/app/templates/road-marking-concepts/road-marking-concept.hbs
+++ b/app/templates/road-marking-concepts/road-marking-concept.hbs
@@ -253,7 +253,9 @@
             </AuLabel>
             <PowerSelect
               @allowClear={{true}}
+              @placeholder={{t "utility.search-placeholder"}}
               @searchEnabled={{true}}
+              @searchMessage={{t "utility.search-placeholder"}}
               @noMatchesMessage={{t "road-sign-concept.crud.no-data"}}
               @loadingMessage={{t "utility.loading"}}
               @searchField="label"

--- a/app/templates/road-marking-concepts/road-marking-concept/instruction.hbs
+++ b/app/templates/road-marking-concepts/road-marking-concept/instruction.hbs
@@ -1,4 +1,4 @@
-{{page-title "instructie"}}
+{{page-title (t "utility.add-instruction")}}
 <AddInstruction
   @from={{this.model.from}}
   @editedTemplate={{this.model.template}}

--- a/app/templates/road-sign-concepts/road-sign-concept.hbs
+++ b/app/templates/road-sign-concepts/road-sign-concept.hbs
@@ -382,7 +382,9 @@
             </AuLabel>
             <PowerSelect
               @allowClear={{true}}
+              @placeholder={{t "utility.search-placeholder"}}
               @searchEnabled={{true}}
+              @searchMessage={{t "utility.search-placeholder"}}
               @noMatchesMessage={{t "road-sign-concept.crud.no-data"}}
               @loadingMessage={{t "utility.loading"}}
               @searchField="label"
@@ -445,7 +447,9 @@
             </AuLabel>
             <PowerSelect
               @allowClear={{true}}
+              @placeholder={{t "utility.search-placeholder"}}
               @searchEnabled={{true}}
+              @searchMessage={{t "utility.search-placeholder"}}
               @noMatchesMessage={{t "road-sign-concept.crud.no-data"}}
               @loadingMessage={{t "utility.loading"}}
               @searchField="label"

--- a/app/templates/road-sign-concepts/road-sign-concept/instruction.hbs
+++ b/app/templates/road-sign-concepts/road-sign-concept/instruction.hbs
@@ -1,4 +1,4 @@
-{{page-title "instructie"}}
+{{page-title (t "utility.add-instruction")}}
 <AddInstruction
   @from={{this.model.from}}
   @editedTemplate={{this.model.template}}

--- a/app/templates/traffic-light-concepts/traffic-light-concept.hbs
+++ b/app/templates/traffic-light-concepts/traffic-light-concept.hbs
@@ -175,7 +175,9 @@
             </AuLabel>
             <PowerSelect
               @allowClear={{true}}
+              @placeholder={{t "utility.search-placeholder"}}
               @searchEnabled={{true}}
+              @searchMessage={{t "utility.search-placeholder"}}
               @noMatchesMessage={{t "road-sign-concept.crud.no-data"}}
               @searchField="label"
               @options={{@model.roadSignCategories}}

--- a/app/templates/traffic-light-concepts/traffic-light-concept/instruction.hbs
+++ b/app/templates/traffic-light-concepts/traffic-light-concept/instruction.hbs
@@ -1,4 +1,4 @@
-{{page-title "instructie"}}
+{{page-title (t "utility.add-instruction")}}
 <AddInstruction
   @from={{this.model.from}}
   @editedTemplate={{this.model.template}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1,11 +1,21 @@
 auth:
   simple:
     title: Enter your username and password to log in
-  mock: 
+  mock:
     title: Choose an account to log in with.
   acmidm:
     title: Log in with acm/idm
   login: Login
+login-page:
+  header:
+    title:
+      part-one: Flanders
+      part-two: is local governance
+    image-alt: laptop with the flanders logo
+  footer:
+    heading: register.mobiliteit.vlaanderen.be is an official website of the Flemish government
+    published-by: Published by
+    abb: Agency for Home Affairs
 utility:
   login: Login
   logout: Logout
@@ -50,6 +60,7 @@ utility:
     location: location
     codelist: codelist
     instruction: instruction
+  search-placeholder: Type to search
 image-input:
   helptext: Press the button to upload a new image or insert a URL of an existing image
   preview-alt: A preview of the uploaded or linked image
@@ -156,6 +167,7 @@ traffic-measure-concept:
   name: Traffic measure
   help: Add $'{variableName} to add a variable/instruction
   attr:
+    name: Name
     temporal: Temporal signage
     traffic-sign: Traffic sign
     code: Code

--- a/translations/nl-be.yaml
+++ b/translations/nl-be.yaml
@@ -1,11 +1,21 @@
 auth:
   simple:
     title: Voer uw gebruikersnaam en wachtwoord in om in te loggen
-  mock: 
+  mock:
     title: Kies een bestuurseenheid om mee in te loggen
   acmidm:
     title: Log in met acm/idm
   login: Meld u aan
+login-page:
+  header:
+    title:
+      part-one: Vlaanderen
+      part-two: is lokaal bestuur
+    image-alt: laptop met daarop het vlaanderen logo
+  footer:
+    heading: register.mobiliteit.vlaanderen.be is een officiële website van de Vlaamse overheid
+    published-by: Uitgegeven door
+    abb: Agentschap Binnenlands Bestuur
 utility:
   login: Aanmelden
   logout: Afmelden
@@ -25,7 +35,7 @@ utility:
   zonal: Zonaal
   nonZonal: Niet zonaal
   potentiallyZonal: Potentieel zonaal
-  upload: Opladen
+  upload: Uploaden
   or: Of
   field-required: Dit veld is verplicht
   app-name: MOW Register
@@ -51,6 +61,7 @@ utility:
     location: locatie
     codelist: codelijst
     instruction: instructie
+  search-placeholder: Typ om te zoeken
 image-input:
   helptext: Druk op de upload knop om een nieuw bestand te uploaden of plak de URL van een bestaande afbeelding
   preview-alt: Een voorbeeld van het geüploade bestand of de URL
@@ -150,6 +161,7 @@ traffic-measure-concept:
   name: Mobiliteitsmaatregel
   help: Voeg in $'{variableName} toe om een variabele/instructie toe te voegen
   attr:
+    name: Naam
     temporal: Variabele signalisatie
     traffic-sign: Verkeersteken
     code: Code
@@ -181,7 +193,7 @@ sub-sign:
     delete: Onderbord verwijderen
 main-sign:
   attr:
-    category: Zoek verkeersborden op category
+    category: Zoek verkeersborden op categorie
   crud:
     add: Hoofdborden toevoegen
     add-one: Hoofdbord toevoegen
@@ -189,7 +201,7 @@ main-sign:
     edit: Hoofdbord bewerken
 related-road-sign:
   attr:
-    category: Zoek verkeersborden op category
+    category: Zoek verkeersborden op categorie
   crud:
     add: Gerelateerde verkeersborden toevoegen
     add-one: Gerelateerd verkeersbord toevoegen


### PR DESCRIPTION
## Overview
This PR includes the following changes:
- Addition of the `no-bare-strings` template-lint rule
- Fill-in of missing translations on login page
- Fill-in of missing translations in tables
- Fix translations of ember-power-select placeholders
- Fill-in missing translations of `required`-pill
- Fill-in missing page-title translations

##### connected issues and PRs:
[GN-4398](https://binnenland.atlassian.net/browse/GN-4398?atlOrigin=eyJpIjoiMTA4NDJhMTA4MjcwNGE0ZmJhNjk5YzliNjI4OGM4ZGYiLCJwIjoiaiJ9)

### How to test/reproduce
- Run the app
- Check if any translations are wrong/missing

### Challenges/uncertainties
- The `volgende`/`vorige` buttons of the paginated tables are not internationalized as these are hardcoded in the `@appuniversum/ember-appuniversum` package



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations