### PR TITLE
feat(variables): show alert to users if template variable names contain invalid characters

### DIFF
--- a/.changeset/beige-dryers-care.md
+++ b/.changeset/beige-dryers-care.md
@@ -1,0 +1,5 @@
+---
+'mow-registry': patch
+---
+
+Show alert to user when template variable names contain invalid characters

--- a/app/components/add-instruction.hbs
+++ b/app/components/add-instruction.hbs
@@ -13,7 +13,7 @@
         <button
           type="button"
           class="au-c-close au-c-close--large"
-          {{on 'click' this.reset}}
+          {{on "click" this.reset}}
         >
           <AuIcon @icon="cross" @size="large" />
           <span class="au-u-hidden-visually">
@@ -25,19 +25,37 @@
     </div>
     <div class="au-c-body-container au-c-body-container--scroll">
       <div class="au-o-box au-c-form">
-        <p>
-          <AuLabel for="textarea-description">{{t "utility.description"}}</AuLabel>
-          <AuTextarea {{on "input" this.updateTemplate}} id="textarea-description" @width="block" @value={{this.template.value}} />
-        </p>
+        <AuFormRow>
+          <AuLabel for="textarea-description">{{t
+              "utility.description"
+            }}</AuLabel>
+          <AuTextarea
+            {{on "input" this.updateTemplate}}
+            id="textarea-description"
+            @width="block"
+            @value={{this.template.value}}
+          />
+          {{#if this.templateSyntaxError}}
+            <AuAlert
+              @title={{this.templateSyntaxError.title}}
+              @skin="error"
+              @icon="alert-triangle"
+              class="au-u-margin-top-small"
+            >
+              {{this.templateSyntaxError.message}}
+            </AuAlert>
+          {{/if}}
+        </AuFormRow>
+
         <AuButtonGroup>
           <AuButton
-            {{on 'click' (perform this.save)}}
-            @disabled={{this.save.isRunning}}
+            {{on "click" (perform this.save)}}
+            @disabled={{not this.canSave}}
             @loading={{this.save.isRunning}}
           >
-            {{t "utility.save" }}
+            {{t "utility.save"}}
           </AuButton>
-          <AuButton @skin="secondary" {{on 'click' this.reset}}>
+          <AuButton @skin="secondary" {{on "click" this.reset}}>
             {{t "utility.cancel"}}
           </AuButton>
         </AuButtonGroup>
@@ -50,39 +68,41 @@
             </tr>
           </thead>
           <tbody>
-          {{#each this.mappings as |mapping|}}
-            <tr>
-              <td>{{mapping.variable}}</td>
-              {{!-- template-lint-disable no-inline-styles --}}
-              <td style="width: 50%;">
-                <PowerSelect
-                  @allowClear={{false}}
-                  @searchEnabled={{false}}
-                  @options={{this.inputTypes}}
-                  @selected={{mapping.type}}
-                  @onChange={{fn this.updateMappingType mapping}} as |type|
-                >
-                  {{type}}
-                </PowerSelect>
-                {{#if (eq mapping.type "codelist")}}
+            {{#each this.mappings as |mapping|}}
+              <tr>
+                <td>{{mapping.variable}}</td>
+                {{! template-lint-disable no-inline-styles }}
+                <td style="width: 50%;">
                   <PowerSelect
                     @allowClear={{false}}
                     @searchEnabled={{false}}
-                    @options={{this.codeLists}}
-                    @selected={{mapping.codeList}}
-                    @onChange={{fn this.updateCodeList mapping}} as |codeList|
+                    @options={{this.inputTypes}}
+                    @selected={{mapping.type}}
+                    @onChange={{fn this.updateMappingType mapping}}
+                    as |type|
                   >
-                    {{codeList.label}}
+                    {{type}}
                   </PowerSelect>
-                  <ul>
-                  {{#each mapping.codeList.concepts as |option|}}
-                    <li> - {{option.label}}</li>
-                  {{/each}}
-                  </ul>
-                {{/if}}
-              </td>
-            </tr>
-          {{/each}}
+                  {{#if (eq mapping.type "codelist")}}
+                    <PowerSelect
+                      @allowClear={{false}}
+                      @searchEnabled={{false}}
+                      @options={{this.codeLists}}
+                      @selected={{mapping.codeList}}
+                      @onChange={{fn this.updateCodeList mapping}}
+                      as |codeList|
+                    >
+                      {{codeList.label}}
+                    </PowerSelect>
+                    <ul>
+                      {{#each mapping.codeList.concepts as |option|}}
+                        <li> - {{option.label}}</li>
+                      {{/each}}
+                    </ul>
+                  {{/if}}
+                </td>
+              </tr>
+            {{/each}}
           </tbody>
         </table>
 

--- a/app/components/add-instruction.js
+++ b/app/components/add-instruction.js
@@ -76,8 +76,7 @@ export default class AddInstructionComponent extends Component {
     // Regex which tests if variables in the template occur containing non-allowed characters:
     // (characters which are not: letters, numbers, '-', '.', '_', '}')
     const regex = new RegExp(/\${[^}]*?[^a-zA-Z\d\-_.}]+?[^}]*?}/g);
-    const next = this.template.value.matchAll(regex).next();
-    const containsInvalidCharacters = !next.done;
+    const containsInvalidCharacters = regex.test(this.template.value);
 
     if (containsInvalidCharacters) {
       return {

--- a/app/components/add-instruction.js
+++ b/app/components/add-instruction.js
@@ -9,6 +9,7 @@ export default class AddInstructionComponent extends Component {
   @service store;
   @service router;
   @service('codelists') codeListService;
+  @service intl;
 
   @tracked template;
   @tracked concept;
@@ -66,6 +67,29 @@ export default class AddInstructionComponent extends Component {
   updateTemplate(event) {
     this.template.value = event.target.value;
     this.parseTemplate();
+  }
+
+  get templateSyntaxError() {
+    if (!this.template || !this.template.value) {
+      return null;
+    }
+    // Regex which tests if variables in the template occur containing non-allowed characters:
+    // (characters which are not: letters, numbers, '-', '.', '_', '}')
+    const regex = new RegExp(/\${[^}]*?[^a-zA-Z\d\-_.}]+?[^}]*?}/g);
+    const next = this.template.value.matchAll(regex).next();
+    const containsInvalidCharacters = !next.done;
+
+    if (containsInvalidCharacters) {
+      return {
+        title: this.intl.t(
+          'utility.template-variables.invalid-character.title',
+        ),
+        message: this.intl.t(
+          'utility.template-variables.invalid-character.message',
+        ),
+      };
+    }
+    return null;
   }
 
   //only resetting things we got from parent component
@@ -165,6 +189,10 @@ export default class AddInstructionComponent extends Component {
     });
 
     this.mappings = sortedMappings;
+  }
+
+  get canSave() {
+    return !this.save.isRunning && !this.templateSyntaxError;
   }
 
   save = task(async () => {

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -60,6 +60,9 @@ utility:
     location: location
     codelist: codelist
     instruction: instruction
+    invalid-character:
+      title: Invalid character detected
+      message: One of the mentioned variable names contains an invalid character. Variable names may only contains letters, numbers, '-', '_' and '.'
   search-placeholder: Type to search
 image-input:
   helptext: Press the button to upload a new image or insert a URL of an existing image

--- a/translations/nl-be.yaml
+++ b/translations/nl-be.yaml
@@ -61,6 +61,9 @@ utility:
     location: locatie
     codelist: codelijst
     instruction: instructie
+    invalid-character:
+      title: Ongeldig karakter gedetecteerd
+      message: Een van de opgegeven variabelenamen bevat een ongeldig karakter. Variabelenamen mogen enkel letters, cijfers, '-', '_' en '.' bevatten
   search-placeholder: Typ om te zoeken
 image-input:
   helptext: Druk op de upload knop om een nieuw bestand te uploaden of plak de URL van een bestaande afbeelding


### PR DESCRIPTION
## Overview
This PR improves the handling of invalid characters showing up in template variables:
- An alert is shown to the user when a variable name contains an invalid character
- The 'save' button is disabled when a variable name contains an invalid character

##### connected issues and PRs:
None

### How to test/reproduce
- Start the application
- Open up a traffic sign/road sign/traffic light
- Open the template editor of one of its instructions
- Type in a variable-name with invalid characters (any character outside of numbers, letters, '.', '_' and '-')
- Notice that an alert shows up and the 'save' button is disabled
- The alert should not show up when using valid characters inside variable names or using invalid characters outside of variable names

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations