### PR TITLE
Assign default zonality to new road-signs and traffic-measures

### DIFF
--- a/.changeset/olive-brooms-smash.md
+++ b/.changeset/olive-brooms-smash.md
@@ -1,0 +1,5 @@
+---
+'mow-registry': patch
+---
+
+Ensure that traffic-measures and road-signs have a default zonality of 'non-zonal'

--- a/app/components/zonality-selector.ts
+++ b/app/components/zonality-selector.ts
@@ -1,12 +1,12 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { ZON_NON_ZONAL_ID, ZON_CONCEPT_SCHEME_ID } from '../utils/constants';
+import { ZON_CONCEPT_SCHEME_ID } from '../utils/constants';
 import type Store from '@ember-data/store';
 import SkosConcept from 'mow-registry/models/skos-concept';
 import { trackedFunction } from 'ember-resources/util/function';
 type Args = {
-  zonality?: SkosConcept;
-  onChange: (zonality?: SkosConcept) => void;
+  zonality: SkosConcept;
+  onChange: (zonality: SkosConcept) => void;
 };
 export default class ZonalitySelectorComponent extends Component<Args> {
   @service declare store: Store;
@@ -20,12 +20,6 @@ export default class ZonalitySelectorComponent extends Component<Args> {
   });
 
   get selectedZonality() {
-    if (this.args.zonality) {
-      return this.args.zonality;
-    } else {
-      return this.zonalities.value?.find(
-        (zonality) => zonality.id == ZON_NON_ZONAL_ID,
-      );
-    }
+    return this.args.zonality;
   }
 }

--- a/app/routes/road-sign-concepts/new.ts
+++ b/app/routes/road-sign-concepts/new.ts
@@ -1,14 +1,21 @@
 import Store from '@ember-data/store';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { ZON_NON_ZONAL_ID } from 'mow-registry/utils/constants';
 import { hash } from 'rsvp';
 
 export default class RoadsignConceptsNewRoute extends Route {
   @service declare store: Store;
 
-  model() {
+  async model() {
+    const nonZonalConcept = await this.store.findRecord(
+      'skos-concept',
+      ZON_NON_ZONAL_ID,
+    );
     return hash({
-      newRoadSignConcept: this.store.createRecord('road-sign-concept'),
+      newRoadSignConcept: this.store.createRecord('road-sign-concept', {
+        zonality: nonZonalConcept,
+      }),
       categories: this.store.findAll('road-sign-category'),
     });
   }

--- a/app/routes/traffic-measure-concepts/new.ts
+++ b/app/routes/traffic-measure-concepts/new.ts
@@ -1,14 +1,22 @@
 import Store from '@ember-data/store';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { ZON_NON_ZONAL_ID } from 'mow-registry/utils/constants';
 
 export default class TrafficMeasureConceptsNewRoute extends Route {
   @service declare store: Store;
 
-  model() {
+  async model() {
+    const nonZonalConcept = await this.store.findRecord(
+      'skos-concept',
+      ZON_NON_ZONAL_ID,
+    );
     const template = this.store.createRecord('template');
     const trafficMeasureConcept = this.store.createRecord(
       'traffic-measure-concept',
+      {
+        zonality: nonZonalConcept,
+      },
     );
 
     template.value = '';


### PR DESCRIPTION
## Overview
This PR ensures that a default zonality of 'non-zonal' gets assigned to newly created road-signs and traffic-measures

##### connected issues and PRs:
None

### How to test/reproduce
- Start the application
- Create a new road-sign/traffic-measure
- Using the sparql endpoint/ember-data inspector, ensure that the newly created resource has a default zonality of 'non-zonal' assigned. The zonality may not be empty.



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations