### PR TITLE
Add hacky workaround to ensure traffic-lights and road-markings can be correctly consumed

### DIFF
--- a/.changeset/stale-eyes-shake.md
+++ b/.changeset/stale-eyes-shake.md
@@ -1,0 +1,7 @@
+---
+'mow-registry': patch
+---
+
+Add hacky workaround to ensure road-marking and traffic-light concepts can be correctly consumed:
+- Addition of a `zonality` relationship to road-marking and traffic-light concepts
+- Give new road-marking and traffic-light concepts a default zonality of 'non-zonal'

--- a/app/models/road-marking-concept.ts
+++ b/app/models/road-marking-concept.ts
@@ -9,6 +9,7 @@ import ConceptModel from 'mow-registry/models/concept';
 import type RoadSignConceptModel from 'mow-registry/models/road-sign-concept';
 import type RoadSignConceptStatusCodeModel from 'mow-registry/models/road-sign-concept-status-code';
 import type TrafficLightConceptModel from 'mow-registry/models/traffic-light-concept';
+import SkosConcept from './skos-concept';
 
 declare module 'ember-data/types/registries/model' {
   export default interface ModelRegistry {
@@ -31,6 +32,9 @@ export default class RoadMarkingConceptModel extends ConceptModel {
     async: true,
   })
   declare status: AsyncBelongsTo<RoadSignConceptStatusCodeModel>;
+
+  @belongsTo('skos-concept', { inverse: null, async: true })
+  declare zonality: AsyncBelongsTo<SkosConcept>;
 
   @hasMany('road-marking-concept', {
     inverse: 'relatedFromRoadMarkingConcepts',

--- a/app/models/traffic-light-concept.ts
+++ b/app/models/traffic-light-concept.ts
@@ -9,6 +9,7 @@ import ConceptModel from './concept';
 import type TrafficLightConceptStatusCodeModel from 'mow-registry/models/traffic-light-concept-status-code';
 import type RoadSignConceptModel from 'mow-registry/models/road-sign-concept';
 import type RoadMarkingConceptModel from 'mow-registry/models/road-marking-concept';
+import SkosConcept from './skos-concept';
 
 declare module 'ember-data/types/registries/model' {
   export default interface ModelRegistry {
@@ -30,6 +31,9 @@ export default class TrafficLightConceptModel extends ConceptModel {
     async: true,
   })
   declare status: AsyncBelongsTo<TrafficLightConceptStatusCodeModel>;
+
+  @belongsTo('skos-concept', { inverse: null, async: true })
+  declare zonality: AsyncBelongsTo<SkosConcept>;
 
   @hasMany('traffic-light-concept', {
     inverse: 'relatedFromTrafficLightConcepts',

--- a/app/routes/road-marking-concepts/new.ts
+++ b/app/routes/road-marking-concepts/new.ts
@@ -1,14 +1,21 @@
 import Store from '@ember-data/store';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { ZON_NON_ZONAL_ID } from 'mow-registry/utils/constants';
 import { hash } from 'rsvp';
 
 export default class RoadmarkingConceptsNewRoute extends Route {
   @service declare store: Store;
 
-  model() {
+  async model() {
+    const nonZonalConcept = await this.store.findRecord(
+      'skos-concept',
+      ZON_NON_ZONAL_ID,
+    );
     return hash({
-      newRoadMarkingConcept: this.store.createRecord('road-marking-concept'),
+      newRoadMarkingConcept: this.store.createRecord('road-marking-concept', {
+        zonality: nonZonalConcept,
+      }),
     });
   }
 }

--- a/app/routes/traffic-light-concepts/new.ts
+++ b/app/routes/traffic-light-concepts/new.ts
@@ -1,14 +1,21 @@
 import Store from '@ember-data/store';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { ZON_NON_ZONAL_ID } from 'mow-registry/utils/constants';
 import { hash } from 'rsvp';
 
 export default class TrafficlightConceptsNewRoute extends Route {
   @service declare store: Store;
 
-  model() {
+  async model() {
+    const nonZonalConcept = await this.store.findRecord(
+      'skos-concept',
+      ZON_NON_ZONAL_ID,
+    );
     return hash({
-      newTrafficLightConcept: this.store.createRecord('traffic-light-concept'),
+      newTrafficLightConcept: this.store.createRecord('traffic-light-concept', {
+        zonality: nonZonalConcept,
+      }),
     });
   }
 }


### PR DESCRIPTION
## Overview
Add hacky workaround to ensure road-marking and traffic-light concepts can be correctly consumed:
- Addition of a `zonality` relationship to road-marking and traffic-light concepts
- Give new road-marking and traffic-light concepts a default zonality of 'non-zonal'