### PR TITLE
Fix model tests

### DIFF
--- a/.woodpecker/.test-pr.yml
+++ b/.woodpecker/.test-pr.yml
@@ -12,6 +12,5 @@ steps:
     image: danlynn/ember-cli:4.12.1
     commands:
       - npm run test:ember
-    failure: ignore
 when:
   event: pull_request

--- a/app/validators/schema.ts
+++ b/app/validators/schema.ts
@@ -7,7 +7,7 @@ import Joi from 'joi';
  * @param {string} [message] - Custom error message for validation failure.
  */
 export const validateBelongsToRequired = (
-  message = 'errors.field.required.',
+  message = 'errors.field.required',
 ) => {
   return Joi.object().required().messages({ 'any.required': message });
 };

--- a/tests/unit/models/road-marking-concept-test.js
+++ b/tests/unit/models/road-marking-concept-test.js
@@ -16,7 +16,7 @@ module('Unit | Model | road marking concept', function (hooks) {
 
     assert.false(isValid);
     assert.strictEqual(Object.keys(model.error).length, 4);
-    assert.strictEqual(model.error.image.message, 'errors.label.required');
+    assert.strictEqual(model.error.image.message, 'errors.field.required');
     assert.strictEqual(model.error.definition.message, 'errors.label.required');
     assert.strictEqual(model.error.meaning.message, 'errors.label.required');
     assert.strictEqual(model.error.label.message, 'errors.label.required');

--- a/tests/unit/models/road-sign-concept-test.js
+++ b/tests/unit/models/road-sign-concept-test.js
@@ -15,16 +15,15 @@ module('Unit | Model | road sign concept', function (hooks) {
     const isValid = await model.validate();
 
     assert.false(isValid);
-    assert.strictEqual(Object.keys(model.error).length, 4);
-    assert.strictEqual(model.error.image.message, 'errors.label.required');
+    assert.strictEqual(Object.keys(model.error).length, 5);
+    assert.strictEqual(model.error.image.message, 'errors.field.required');
     assert.strictEqual(model.error.meaning.message, 'errors.label.required');
     assert.strictEqual(model.error.label.message, 'errors.label.required');
     assert.strictEqual(
       model.error.classifications.message,
       'errors.field.required',
     );
-    assert.strictEqual(model.error.shape.message, 'errors.label.required');
-    assert.strictEqual(model.error.shape.dimensions, 'errors.label.required');
+    assert.strictEqual(model.error.shape.message, 'errors.field.required');
   });
 
   test('it does not have error when all required fields are filled in', async function (assert) {
@@ -33,7 +32,7 @@ module('Unit | Model | road sign concept', function (hooks) {
       meaning: 'meaning',
       classifications: [this.store().createRecord('road-sign-category')],
       label: 'label',
-      shape: this.store().createRecord('shape'),
+      shape: this.store().createRecord('tribont-shape'),
       dimensions: [this.store().createRecord('dimension')],
     });
 

--- a/tests/unit/models/traffic-light-concept-test.js
+++ b/tests/unit/models/traffic-light-concept-test.js
@@ -16,7 +16,7 @@ module('Unit | Model | traffic light concept', function (hooks) {
 
     assert.false(isValid);
     assert.strictEqual(Object.keys(model.error).length, 4);
-    assert.strictEqual(model.error.image.message, 'errors.label.required');
+    assert.strictEqual(model.error.image.message, 'errors.field.required');
     assert.strictEqual(model.error.definition.message, 'errors.label.required');
     assert.strictEqual(model.error.meaning.message, 'errors.label.required');
     assert.strictEqual(model.error.label.message, 'errors.label.required');


### PR DESCRIPTION
## Overview

Test were in a broken state, but it wasn't visible in CI due to `failure: ignore` in Woodpecker config. 

Done: 
- fix broken tests
- remove `failure: ignore` in Woodpecker config