### PR TITLE
Discard changeset validation when not target master

### DIFF
--- a/.woodpecker/.changeset.yml
+++ b/.woodpecker/.changeset.yml
@@ -5,4 +5,4 @@ steps:
       - git fetch origin master
       - git diff -wb --name-only origin/master..HEAD | grep "\.changeset/.*\.md"
 when:
-  - evaluate: 'CI_PIPELINE_EVENT == "pull_request" && not (CI_COMMIT_PULL_REQUEST_LABELS contains "dependabot")'
+  - evaluate: 'CI_PIPELINE_EVENT == "pull_request" && CI_COMMIT_TARGET_BRANCH == "master" && not (CI_COMMIT_PULL_REQUEST_LABELS contains "dependabot")'


### PR DESCRIPTION
## Overview

`\.changeset/.*\.md` is required when the PR target `master`. 

This PR add rule to exclude the task when PR target other branch. 