### PR TITLE
Fix traffic-light-form disabled button logic

### DIFF
--- a/app/components/traffic-light-form.hbs
+++ b/app/components/traffic-light-form.hbs
@@ -131,7 +131,7 @@
     <AuButtonGroup>
       {{! or @trafficLightConcept.error   }}
       <AuButton
-        @disabled={{this.isSaving}}
+        @disabled={{or @trafficLightConcept.error this.isSaving}}
         @loading={{this.isSaving}}
         form="edit-traffic-light-concept-form"
         {{on "click" (perform this.editTrafficLightConceptTask)}}


### PR DESCRIPTION
## Overview

Fix `traffic-light-form` disabled button logic. 

## Before

![image](https://github.com/user-attachments/assets/ecc2d604-63df-4a54-a847-cbed371dfc9c)

## After 

![image](https://github.com/user-attachments/assets/b0fa0467-e24c-4694-b6ee-47224ec43df9)
