### PR TITLE
Display linked codelist in icon catalog

### DIFF
--- a/app/components/search-tables/icon-catalog.hbs
+++ b/app/components/search-tables/icon-catalog.hbs
@@ -18,6 +18,7 @@
       @field="label"
       @label={{t "icon-catalog.attr.label"}}
     />
+    <th>{{t "icon-catalog.crud.use-in-codelist"}}</th>
     <th></th>
   </:header>
   <:body as |icon|>
@@ -26,6 +27,9 @@
     </td>
     <td>
       {{icon.label}}
+    </td>
+    <td>
+      {{icon.inScheme.length}}
     </td>
     <td>
       {{yield icon to="rowAction"}}

--- a/app/models/skos-concept.ts
+++ b/app/models/skos-concept.ts
@@ -1,8 +1,8 @@
-import { AsyncBelongsTo, attr, belongsTo } from '@ember-data/model';
+import { AsyncBelongsTo, attr, hasMany } from '@ember-data/model';
 import Joi from 'joi';
 import type ConceptScheme from 'mow-registry/models/concept-scheme';
 import {
-  validateBelongsToOptional,
+  validateHasManyOptional,
   validateStringOptional,
   validateStringRequired,
 } from 'mow-registry/validators/schema';
@@ -16,7 +16,7 @@ declare module 'ember-data/types/registries/model' {
 export default class SkosConcept extends AbstractValidationModel {
   @attr declare uri?: string;
   @attr declare label?: string;
-  @belongsTo('concept-scheme', {
+  @hasMany('concept-scheme', {
     inverse: 'concepts',
     polymorphic: true,
     async: true,
@@ -26,7 +26,7 @@ export default class SkosConcept extends AbstractValidationModel {
     return Joi.object({
       uri: validateStringOptional(),
       label: validateStringRequired(),
-      inScheme: validateBelongsToOptional(),
+      inScheme: validateHasManyOptional(),
     });
   }
 }

--- a/app/templates/icon-catalog/icon.hbs
+++ b/app/templates/icon-catalog/icon.hbs
@@ -11,9 +11,7 @@
 </BreadcrumbsItem>
 
 <div class="au-o-grid au-o-grid--flush au-o-grid--fixed">
-  <div
-    class="au-o-grid__item au-u-1-1@medium"
-  >
+  <div class="au-o-grid__item au-u-1-1@medium">
     <div class="au-c-body-container au-c-body-container--scroll">
       <AuToolbar @size="large" as |Group|>
         <Group>
@@ -41,8 +39,31 @@
               </p>
             </li>
           </ul>
+
         </Group>
       </AuToolbar>
+      <SearchTables::Codelist
+        @content={{@model.icon.inScheme}}
+      >
+        <:menu>
+          <AuToolbar class="au-o-box" as |Group|>
+            <Group @size="large">
+              <AuHeading @skin="4">
+                {{t "icon-catalog.crud.use-in-codelist"}}
+              </AuHeading>
+            </Group>
+          </AuToolbar>
+        </:menu>
+        <:rowAction as |codelist|>
+          <AuLink
+            @skin="primary"
+            @route="codelists-management.codelist"
+            @model={{codelist.id}}
+          >
+            {{t "utility.view"}}
+          </AuLink>
+        </:rowAction>
+      </SearchTables::Codelist>
       <AuToolbar @border="bottom" @size="large" as |Group|>
         <Group>
           <AuLink
@@ -54,6 +75,7 @@
           </AuLink>
           <AuButton
             @skin="secondary"
+            @disabled={{@model.icon.inScheme.length}}
             @alert={{true}}
             {{on "click" (fn (mut this.isOpen) true)}}
           >
@@ -73,9 +95,10 @@
             <Modal.Footer>
               <AuButton
                 @alert={{true}}
-                {{on
-                  "click"
-                  (perform
+                @disabled={{@model.icon.inScheme.length}}
+                {{on 
+                  "click" 
+                  (perform 
                     this.removeIcon @model.icon
                   )
                 }}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -242,6 +242,7 @@ icon-catalog:
   attr:
     image: Image
     label: Label
+    used: Used
   crud:
     new: New icon
     no-data: No icon
@@ -250,6 +251,7 @@ icon-catalog:
     save: Save icon
     label-filter: Label
     no-matches: No results found
+    use-in-codelist: Use in codelist
   landing-page:
     content: Manage codelist icons.
     button: Go to Icon Catalog

--- a/translations/nl-be.yaml
+++ b/translations/nl-be.yaml
@@ -243,6 +243,7 @@ icon-catalog:
   attr:
     image: Afbeelding
     label: Label
+    used: Gebruikt
   crud:
     new: Nieuwe pictogram
     no-data: Geen pictogram
@@ -251,6 +252,7 @@ icon-catalog:
     save: Pictogram bewaren
     label-filter: Label
     no-matches: Geen resultaten gevonden
+    use-in-codelist: Gebruik in codelijst
   landing-page:
     content: Overzichtscode bevat pictogrammen.
     button: Ga naar Cataloguspictogram


### PR DESCRIPTION
## Overview
- Display count of codelist that use icon in icon-catalog table
- Display linked codelist in icon view
- Disable delete icon when it's used in codelist

![image](https://github.com/user-attachments/assets/fc81a7a3-f945-455c-9145-421ab447a955)

![image](https://github.com/user-attachments/assets/fc26c413-3579-42b1-a3f1-8c8cb895e5d9)

##### connected issues and PRs:
Related to GN-4919
Depends of https://github.com/lblod/frontend-mow-registry/pull/254