### PR TITLE
remove all instances of definition

### DIFF
--- a/.changeset/quick-items-search.md
+++ b/.changeset/quick-items-search.md
@@ -1,0 +1,5 @@
+---
+'mow-registry': patch
+---
+
+Remove all instances of "definition"

--- a/app/components/related-roadmarkings-table.hbs
+++ b/app/components/related-roadmarkings-table.hbs
@@ -29,9 +29,6 @@
         {{t "road-marking-concept.attr.image-header"}}
       </th>
       <th class="data-table__header-title">
-        {{t "road-marking-concept.attr.definition"}}
-      </th>
-      <th class="data-table__header-title">
         {{t "road-marking-concept.attr.meaning"}}
       </th>
       <th>
@@ -50,11 +47,6 @@
           src={{relatedRoadMarkingConcept.image.file.downloadLink}}
           alt=""
         />
-      </td>
-      <td>
-        <p class="max-w-prose">
-          {{relatedRoadMarkingConcept.definition}}
-        </p>
       </td>
       <td>
         <p class="max-w-prose">

--- a/app/components/related-traffic-lights-table.hbs
+++ b/app/components/related-traffic-lights-table.hbs
@@ -29,9 +29,6 @@
       <th class="data-table__header-title">
         {{t "traffic-light-concept.attr.image-header"}}
       </th>
-      <th class="data-table__header-title">
-        {{t "traffic-light-concept.attr.definition"}}
-      </th>
       <th>
         <span class="au-u-hidden-visually">
           {{t "related-traffic-light.crud.delete"}}
@@ -48,11 +45,6 @@
           src={{relatedTrafficLightConcept.image.file.downloadLink}}
           alt=""
         />
-      </td>
-      <td>
-        <p class="max-w-prose">
-          {{relatedTrafficLightConcept.definition}}
-        </p>
       </td>
       <td class="w-px au-u-padding-right-small">
         <AuButton

--- a/app/components/road-marking-form.hbs
+++ b/app/components/road-marking-form.hbs
@@ -61,32 +61,6 @@
               {{/if}}
             </AuFormRow>
           {{/let}}
-          {{#let @roadMarkingConcept.error.definition as |isInvalid|}}
-            <AuFormRow>
-              <AuLabel
-                @error={{isInvalid}}
-                for="definition"
-                @required={{true}}
-                @requiredLabel={{t "utility.required"}}
-              >
-                {{t "road-marking-concept.attr.definition"}}&nbsp;
-              </AuLabel>
-              <AuTextarea
-                @error={{isInvalid}}
-                @width="block"
-                class="u-min-h-20"
-                id="definition"
-                required="required"
-                @value={{@roadMarkingConcept.definition}}
-                {{on "input" (fn this.setRoadMarkingConceptValue "definition")}}
-              />
-              {{#if isInvalid}}
-                <AuHelpText @error={{true}}>
-                  {{t "utility.field-required"}}
-                </AuHelpText>
-              {{/if}}
-            </AuFormRow>
-          {{/let}}
           {{#let @roadMarkingConcept.error.meaning as |isInvalid|}}
             <AuFormRow>
               <AuLabel

--- a/app/components/traffic-light-form.hbs
+++ b/app/components/traffic-light-form.hbs
@@ -65,35 +65,6 @@
               {{/if}}
             </AuFormRow>
           {{/let}}
-          {{#let @trafficLightConcept.error.definition as |isInvalid|}}
-            <AuFormRow>
-              <AuLabel
-                @error={{isInvalid}}
-                for="definition"
-                @required={{true}}
-                @requiredLabel={{t "utility.required"}}
-              >
-                {{t "traffic-light-concept.attr.definition"}}&nbsp;
-              </AuLabel>
-              <AuTextarea
-                @error={{isInvalid}}
-                @width="block"
-                class="u-min-h-20"
-                id="definition"
-                required="required"
-                @value={{@trafficLightConcept.definition}}
-                {{on
-                  "input"
-                  (fn this.setTrafficLightConceptValue "definition")
-                }}
-              />
-              {{#if isInvalid}}
-                <AuHelpText @error={{true}}>
-                  {{t "utility.field-required"}}
-                </AuHelpText>
-              {{/if}}
-            </AuFormRow>
-          {{/let}}
           {{#let @trafficLightConcept.error.meaning as |isInvalid|}}
             <AuFormRow>
               <AuLabel

--- a/app/controllers/road-marking-concepts/road-marking-concept.ts
+++ b/app/controllers/road-marking-concepts/road-marking-concept.ts
@@ -68,7 +68,7 @@ export default class RoadmarkingConceptsRoadmarkingConceptController extends Con
     }
 
     return this.model.allRoadMarkings.filter((roadMarking) => {
-      return roadMarking.definition
+      return roadMarking.meaning
         ?.toLowerCase()
         .includes(this.relatedRoadMarkingCodeFilter.toLowerCase().trim());
     });
@@ -80,7 +80,7 @@ export default class RoadmarkingConceptsRoadmarkingConceptController extends Con
     }
 
     return this.model.allTrafficLights.filter((trafficLight) => {
-      return trafficLight.definition
+      return trafficLight.meaning
         ?.toLowerCase()
         .includes(this.relatedTrafficLightCodeFilter.toLowerCase().trim());
     });

--- a/app/controllers/road-sign-concepts/road-sign-concept.ts
+++ b/app/controllers/road-sign-concepts/road-sign-concept.ts
@@ -74,7 +74,7 @@ export default class RoadsignConceptsRoadsignConceptController extends Controlle
     }
 
     return this.model.allRoadMarkings.filter((roadMarking) => {
-      return roadMarking.definition
+      return roadMarking.meaning
         ?.toLowerCase()
         .includes(this.relatedRoadMarkingCodeFilter.toLowerCase());
     });
@@ -86,7 +86,7 @@ export default class RoadsignConceptsRoadsignConceptController extends Controlle
     }
 
     return this.model.allTrafficLights.filter((trafficLight) => {
-      return trafficLight.definition
+      return trafficLight.meaning
         ?.toLowerCase()
         .includes(this.relatedTrafficLightCodeFilter.toLowerCase());
     });

--- a/app/controllers/traffic-light-concepts/traffic-light-concept.ts
+++ b/app/controllers/traffic-light-concepts/traffic-light-concept.ts
@@ -51,7 +51,7 @@ export default class TrafficLightConceptsTrafficLightConceptController extends C
     }
 
     return this.model.allTrafficLights.filter((trafficLight) => {
-      return trafficLight.definition
+      return trafficLight.meaning
         ?.toLowerCase()
         .includes(this.relatedTrafficLightCodeFilter.toLowerCase());
     });
@@ -63,7 +63,7 @@ export default class TrafficLightConceptsTrafficLightConceptController extends C
     }
 
     return this.model.allRoadMarkings.filter((roadMarking) => {
-      return roadMarking.definition
+      return roadMarking.meaning
         ?.toLowerCase()
         .includes(this.relatedRoadMarkingCodeFilter.toLowerCase());
     });

--- a/app/models/road-marking-concept.ts
+++ b/app/models/road-marking-concept.ts
@@ -22,8 +22,6 @@ declare module 'ember-data/types/registries/model' {
 }
 
 export default class RoadMarkingConceptModel extends TrafficSignConceptModel {
-  @attr declare definition?: string;
-
   @belongsTo('skos-concept', { inverse: null, async: true })
   declare zonality: AsyncBelongsTo<SkosConcept>;
 
@@ -56,7 +54,6 @@ export default class RoadMarkingConceptModel extends TrafficSignConceptModel {
   get validationSchema() {
     return super.validationSchema.keys({
       meaning: validateStringRequired(),
-      definition: validateStringRequired(),
       zonality: validateBelongsToOptional(),
       relatedToRoadMarkingConcepts: validateHasManyOptional(),
       relatedFromRoadMarkingConcepts: validateHasManyOptional(),

--- a/app/models/road-marking-concept.ts
+++ b/app/models/road-marking-concept.ts
@@ -1,5 +1,4 @@
 import {
-  attr,
   hasMany,
   belongsTo,
   AsyncBelongsTo,

--- a/app/models/traffic-light-concept.ts
+++ b/app/models/traffic-light-concept.ts
@@ -21,8 +21,6 @@ declare module 'ember-data/types/registries/model' {
   }
 }
 export default class TrafficLightConceptModel extends TrafficSignConceptModel {
-  @attr declare definition?: string;
-
   @belongsTo('skos-concept', { inverse: null, async: true })
   declare zonality: AsyncBelongsTo<SkosConcept>;
 
@@ -54,7 +52,6 @@ export default class TrafficLightConceptModel extends TrafficSignConceptModel {
 
   get validationSchema() {
     return super.validationSchema.keys({
-      definition: validateStringRequired(),
       zonality: validateBelongsToOptional(),
       relatedToTrafficLightConcepts: validateHasManyOptional(),
       relatedFromTrafficLightConcepts: validateHasManyOptional(),

--- a/app/models/traffic-light-concept.ts
+++ b/app/models/traffic-light-concept.ts
@@ -1,5 +1,4 @@
 import {
-  attr,
   hasMany,
   belongsTo,
   AsyncBelongsTo,
@@ -12,7 +11,6 @@ import SkosConcept from './skos-concept';
 import {
   validateBelongsToOptional,
   validateHasManyOptional,
-  validateStringRequired,
 } from 'mow-registry/validators/schema';
 
 declare module 'ember-data/types/registries/model' {

--- a/app/templates/road-marking-concepts/road-marking-concept.hbs
+++ b/app/templates/road-marking-concepts/road-marking-concept.hbs
@@ -45,14 +45,6 @@
                 {{@model.roadMarkingConcept.label}}
               </p>
             </li>
-            <li class="au-o-grid__item au-u-1-2 au-u-1-4@medium">
-              <AuLabel>
-                {{t "road-marking-concept.attr.definition"}}
-              </AuLabel>
-              <p>
-                {{@model.roadMarkingConcept.definition}}
-              </p>
-            </li>
             <li class="au-o-grid__item au-u-1-2 au-u-1-3@medium">
               <AuLabel>
                 {{t "road-marking-concept.attr.meaning"}}
@@ -195,7 +187,7 @@
             <SidebarRoadSign
               @imageUrl={{relatedRoadMarking.image.file.downloadLink}}
               @code={{relatedRoadMarking.label}}
-              @meaning={{relatedRoadMarking.definition}}
+              @meaning={{relatedRoadMarking.meaning}}
               @onAdd={{perform this.addRelatedRoadMarking relatedRoadMarking}}
               @addText={{t "related-road-marking.crud.add-one"}}
               class="au-c-action-sidebar__item"
@@ -334,7 +326,7 @@
             <SidebarRoadSign
               @imageUrl={{relatedTrafficLight.image.file.downloadLink}}
               @code={{relatedTrafficLight.label}}
-              @meaning={{relatedTrafficLight.definition}}
+              @meaning={{relatedTrafficLight.meaning}}
               @onAdd={{perform this.addRelatedTrafficLight relatedTrafficLight}}
               @addText={{t "related-traffic-light.crud.add-one"}}
               class="au-c-action-sidebar__item"

--- a/app/templates/road-sign-concepts/road-sign-concept.hbs
+++ b/app/templates/road-sign-concepts/road-sign-concept.hbs
@@ -553,7 +553,7 @@
             <SidebarRoadSign
               @imageUrl={{relatedRoadMarking.image.file.downloadLink}}
               @code={{relatedRoadMarking.label}}
-              @meaning={{relatedRoadMarking.definition}}
+              @meaning={{relatedRoadMarking.meaning}}
               @onAdd={{perform this.addRelatedRoadMarking relatedRoadMarking}}
               @addText={{t "related-road-marking.crud.add-one"}}
               class="au-c-action-sidebar__item"
@@ -625,7 +625,7 @@
             <SidebarRoadSign
               @imageUrl={{relatedTrafficLight.image.file.downloadLink}}
               @code={{relatedTrafficLight.label}}
-              @meaning={{relatedTrafficLight.definition}}
+              @meaning={{relatedTrafficLight.meaning}}
               @onAdd={{perform this.addRelatedTrafficLight relatedTrafficLight}}
               @addText={{t "related-traffic-light.crud.add-one"}}
               class="au-c-action-sidebar__item"

--- a/app/templates/traffic-light-concepts/traffic-light-concept.hbs
+++ b/app/templates/traffic-light-concepts/traffic-light-concept.hbs
@@ -47,14 +47,6 @@
             </li>
             <li class="au-o-grid__item au-u-1-2 au-u-1-4@medium">
               <AuLabel>
-                {{t "traffic-light-concept.attr.definition"}}
-              </AuLabel>
-              <p>
-                {{@model.trafficLightConcept.definition}}
-              </p>
-            </li>
-            <li class="au-o-grid__item au-u-1-2 au-u-1-4@medium">
-              <AuLabel>
                 {{t "traffic-light-concept.attr.meaning"}}
               </AuLabel>
               <p>
@@ -262,7 +254,7 @@
             <SidebarRoadSign
               @imageUrl={{relatedRoadMarking.image.file.downloadLink}}
               @code={{relatedRoadMarking.label}}
-              @meaning={{relatedRoadMarking.definition}}
+              @meaning={{relatedRoadMarking.meaning}}
               @onAdd={{perform this.addRelatedRoadMarking relatedRoadMarking}}
               @addText={{t "related-road-marking.crud.add-one"}}
               class="au-c-action-sidebar__item"
@@ -333,7 +325,7 @@
             <SidebarRoadSign
               @imageUrl={{relatedTrafficLight.image.file.downloadLink}}
               @code={{relatedTrafficLight.label}}
-              @meaning={{relatedTrafficLight.definition}}
+              @meaning={{relatedTrafficLight.meaning}}
               @onAdd={{perform this.addRelatedTrafficLight relatedTrafficLight}}
               @addText={{t "related-traffic-light.crud.add-one"}}
               class="au-c-action-sidebar__item"

--- a/tests/unit/models/road-marking-concept-test.js
+++ b/tests/unit/models/road-marking-concept-test.js
@@ -9,13 +9,13 @@ module('Unit | Model | road marking concept', function (hooks) {
     return this.owner.lookup('service:store');
   };
 
-  test('it has error when mandatory fiels are missing', async function (assert) {
+  test('it has error when mandatory fields are missing', async function (assert) {
     const model = this.store().createRecord('road-marking-concept');
 
     const isValid = await model.validate();
 
     assert.false(isValid);
-    assert.strictEqual(Object.keys(model.error).length, 4);
+    assert.strictEqual(Object.keys(model.error).length, 3);
     assert.strictEqual(model.error.image.message, 'errors.field.required');
     assert.strictEqual(model.error.meaning.message, 'errors.label.required');
     assert.strictEqual(model.error.label.message, 'errors.label.required');

--- a/tests/unit/models/road-marking-concept-test.js
+++ b/tests/unit/models/road-marking-concept-test.js
@@ -17,7 +17,6 @@ module('Unit | Model | road marking concept', function (hooks) {
     assert.false(isValid);
     assert.strictEqual(Object.keys(model.error).length, 4);
     assert.strictEqual(model.error.image.message, 'errors.field.required');
-    assert.strictEqual(model.error.definition.message, 'errors.label.required');
     assert.strictEqual(model.error.meaning.message, 'errors.label.required');
     assert.strictEqual(model.error.label.message, 'errors.label.required');
   });
@@ -26,7 +25,6 @@ module('Unit | Model | road marking concept', function (hooks) {
     const model = this.store().createRecord('road-marking-concept', {
       label: 'label',
       image: this.store().createRecord('image'),
-      definition: 'definition',
       meaning: 'meaning',
     });
 

--- a/tests/unit/models/traffic-light-concept-test.js
+++ b/tests/unit/models/traffic-light-concept-test.js
@@ -17,7 +17,6 @@ module('Unit | Model | traffic light concept', function (hooks) {
     assert.false(isValid);
     assert.strictEqual(Object.keys(model.error).length, 4);
     assert.strictEqual(model.error.image.message, 'errors.field.required');
-    assert.strictEqual(model.error.definition.message, 'errors.label.required');
     assert.strictEqual(model.error.meaning.message, 'errors.label.required');
     assert.strictEqual(model.error.label.message, 'errors.label.required');
   });
@@ -26,7 +25,6 @@ module('Unit | Model | traffic light concept', function (hooks) {
     const model = this.store().createRecord('traffic-light-concept', {
       label: 'label',
       image: this.store().createRecord('image'),
-      definition: 'definition',
       meaning: 'meaning',
     });
 

--- a/tests/unit/models/traffic-light-concept-test.js
+++ b/tests/unit/models/traffic-light-concept-test.js
@@ -9,13 +9,13 @@ module('Unit | Model | traffic light concept', function (hooks) {
     return this.owner.lookup('service:store');
   };
 
-  test('it has error when mandatory fiels are missing', async function (assert) {
+  test('it has error when mandatory fields are missing', async function (assert) {
     const model = this.store().createRecord('traffic-light-concept');
 
     const isValid = await model.validate();
 
     assert.false(isValid);
-    assert.strictEqual(Object.keys(model.error).length, 4);
+    assert.strictEqual(Object.keys(model.error).length, 3);
     assert.strictEqual(model.error.image.message, 'errors.field.required');
     assert.strictEqual(model.error.meaning.message, 'errors.label.required');
     assert.strictEqual(model.error.label.message, 'errors.label.required');

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -115,7 +115,6 @@ traffic-light-concept:
   attr:
     image-header: Image
     meaning: Meaning
-    definition: Definition
     label: Label
     related-traffic-light: Related traffic lights
     related-sign: Related sign
@@ -146,7 +145,6 @@ road-marking-concept:
     image-header: Image
     image-url: Image URL
     meaning: Meaning
-    definition: Definition
     label: Label
     related-sign: Related road signs
     related-marking: Related road markings

--- a/translations/nl-be.yaml
+++ b/translations/nl-be.yaml
@@ -109,7 +109,6 @@ traffic-light-concept:
   attr:
     image-header: Afbeelding
     meaning: Betekenis
-    definition: Definitie
     label: Label
     related-sign: Gerelateerde verkeersborden
     related-marking: Gerelateerde wegmarkeringen
@@ -140,7 +139,6 @@ road-marking-concept:
     image-header: Afbeelding
     image-url: Afbeelding URL
     meaning: Betekenis
-    definition: Definitie
     label: Label
     related-sign: Gerelateerde verkeersborden
     related-marking: Gerelateerde wegmarkeringen


### PR DESCRIPTION
## Overview
Got confirmation that definition field was redundant, so this PR removes all instances of definition in the frontend.

##### connected issues and PRs:
<!-- links to connected jira tickets -->
https://binnenland.atlassian.net/browse/GN-4971
<!-- Link to PRs that are related (and in what way) -->
app: https://github.com/lblod/app-mow-registry/pull/85


