### PR TITLE
GN-4969: Fix sorting bug

### DIFF
--- a/app/components/icon-catalog-form.ts
+++ b/app/components/icon-catalog-form.ts
@@ -17,10 +17,15 @@ export default class IconCatalogFormComponent extends ImageUploadHandlerComponen
 
   @action
   async setIconValue(attributeName: keyof IconModel, event: InputEvent) {
-    await this.args.icon.set(
-      attributeName,
-      (event.target as HTMLInputElement).value,
-    );
+    // remove leading spaces so they don't mess up the sorting mechanism
+    const inputElement = event.target as HTMLInputElement;
+    const trimmedValue = inputElement.value.trimStart();
+    if (inputElement.value !== trimmedValue) {
+      inputElement.value = trimmedValue;
+    }
+    await this.args.icon.set(attributeName, trimmedValue);
+
+    // Validate the icon model
     await this.args.icon.validate();
   }
 

--- a/app/controllers/icon-catalog/index.ts
+++ b/app/controllers/icon-catalog/index.ts
@@ -18,7 +18,7 @@ export default class IconCatalogIndexController extends Controller {
   updateSearchFilterTask = restartableTask(async (event: InputEvent) => {
     await timeout(300);
 
-    this.label = (event.target as HTMLInputElement).value.trim();
+    this.label = (event.target as HTMLInputElement).value.trimStart();
     this.resetPagination();
   });
 

--- a/app/controllers/icon-catalog/index.ts
+++ b/app/controllers/icon-catalog/index.ts
@@ -18,7 +18,7 @@ export default class IconCatalogIndexController extends Controller {
   updateSearchFilterTask = restartableTask(async (event: InputEvent) => {
     await timeout(300);
 
-    this.label = (event.target as HTMLInputElement).value;
+    this.label = (event.target as HTMLInputElement).value.trim();
     this.resetPagination();
   });
 

--- a/app/routes/icon-catalog/index.ts
+++ b/app/routes/icon-catalog/index.ts
@@ -30,9 +30,9 @@ export default class IconCatalogIndexRoute extends Route {
     if (params.label) {
       query['filter[label]'] = params.label;
     }
-    let icons = await this.store.query('icon', query);
+    const icons = await this.store.query('icon', query);
 
-    let sortedIcons = icons.toArray().sort((a, b) => {
+    const sortedIcons = icons.toArray().sort((a, b) => {
       const labelA = (a.label || '').toLowerCase();
       const labelB = (b.label || '').toLowerCase();
 

--- a/app/routes/icon-catalog/index.ts
+++ b/app/routes/icon-catalog/index.ts
@@ -30,9 +30,19 @@ export default class IconCatalogIndexRoute extends Route {
     if (params.label) {
       query['filter[label]'] = params.label;
     }
+    let icons = await this.store.query('icon', query);
+
+    let sortedIcons = icons.toArray().sort((a, b) => {
+      const labelA = (a.label || '').toLowerCase();
+      const labelB = (b.label || '').toLowerCase();
+
+      if (labelA < labelB) return -1;
+      if (labelA > labelB) return 1;
+      return 0;
+    });
 
     return {
-      icons: await this.store.query('icon', query),
+      icons: sortedIcons,
     };
   }
 }

--- a/app/templates/icon-catalog/index.hbs
+++ b/app/templates/icon-catalog/index.hbs
@@ -17,7 +17,7 @@
         {{! Copied from the AuDataTable::TextSearch component since that doesn't support calling actions on input}}
         <div class="au-c-data-table__search">
           <AuInput
-            @value={{this.code}}
+            @value={{this.label}}
             placeholder={{t "icon-catalog.crud.label-filter"}}
             @icon="search"
             @iconAlignment="right"
@@ -31,11 +31,7 @@
     </AuToolbar>
   </:menu>
   <:rowAction as |icon|>
-    <LinkTo
-      class="au-c-link"
-      @route="icon-catalog.icon"
-      @model={{icon.id}}
-    >
+    <LinkTo class="au-c-link" @route="icon-catalog.icon" @model={{icon.id}}>
       {{t "utility.view"}}
     </LinkTo>
   </:rowAction>


### PR DESCRIPTION
## Overview
Tester noticed that labels that started with a space were being placed first when sorting in ascending order. 
The second issue was that labels with capital letters were being placed before the lowercase letters when sorting in ascending order (meaning `FOO` would come before `bar`) 
To fix this i thought of the following solutions: 
1. Labels starting with a leading space don't make sense to me so i took out the ability to have leading spaces on labels. Also in the search component, when starting with a space, the space will be automatically removed so you always search using a valid character.
2. The sorting will now be alphanumerical and case insensitive. 


##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-4969

**Suggestion:** This will only affect the icon catalog. If this gets approved we could use this way of sorting on all modules.