### PR TITLE
Verify types in CI

### DIFF
--- a/app/components/image-upload-handler.ts
+++ b/app/components/image-upload-handler.ts
@@ -2,7 +2,9 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import FileService from 'mow-registry/services/file-service';
 import Store from '@ember-data/store';
-import TrafficSignConceptModel from 'mow-registry/models/traffic-sign-concept';
+import type Model from '@ember-data/model';
+import { type AsyncBelongsTo } from '@ember-data/model';
+import type ImageModel from 'mow-registry/models/image';
 
 /**
  * A helper for uploading images, used in conjunction with `image-input.js`
@@ -22,7 +24,7 @@ export default class ImageUploadHandlerComponent<
     return typeof file === 'string';
   }
 
-  setImage(model: TrafficSignConceptModel, image: File) {
+  setImage(model: ModelWithImage, image: File) {
     this.fileData = image;
     if (!model.image.content) {
       model.set('image', this.store.createRecord('image'));
@@ -39,4 +41,8 @@ export default class ImageUploadHandlerComponent<
     }
     return null;
   }
+}
+
+interface ModelWithImage extends Model {
+  image: AsyncBelongsTo<ImageModel>;
 }

--- a/app/routes/traffic-measure-concepts/new.ts
+++ b/app/routes/traffic-measure-concepts/new.ts
@@ -12,6 +12,7 @@ export default class TrafficMeasureConceptsNewRoute extends Route {
     );
 
     template.value = '';
+    // @ts-expect-error setting belongsTo relationships like this is valid, but TS doesn't like it (yet).
     trafficMeasureConcept.template = template;
 
     return trafficMeasureConcept;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint:hbs:fix": "ember-template-lint . --fix",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
+    "lint:types": "tsc --noEmit",
     "start": "ember serve",
     "test": "concurrently \"npm:lint\" \"npm:test:*\" --names \"lint,test:\"",
     "test:ember": "ember test",


### PR DESCRIPTION
The app is already using TS, but we aren't verifying that our code doesn't trigger type errors.

This adds a new `lint:types` script (which I copied from the TS blueprint) and fixes 2 type errors that were present in the app already.
