### PR TITLE
Appuniversum v3

### DIFF
--- a/app/components/add-instruction.hbs
+++ b/app/components/add-instruction.hbs
@@ -33,7 +33,7 @@
             {{on "input" this.updateTemplate}}
             id="textarea-description"
             @width="block"
-            @value={{this.template.value}}
+            value={{this.template.value}}
           />
           {{#if this.templateSyntaxError}}
             <AuAlert

--- a/app/components/add-instruction.hbs
+++ b/app/components/add-instruction.hbs
@@ -52,6 +52,7 @@
             {{on "click" (perform this.save)}}
             @disabled={{not this.canSave}}
             @loading={{this.save.isRunning}}
+            @loadingMessage={{t "utility.save"}}
           >
             {{t "utility.save"}}
           </AuButton>

--- a/app/components/codelist-form.hbs
+++ b/app/components/codelist-form.hbs
@@ -46,7 +46,7 @@
           @width="block"
           id="label"
           required="required"
-          @value={{@codelist.label}}
+          value={{@codelist.label}}
           {{on "input" (fn this.setCodelistValue "label")}}
         />
         {{#if isInvalid}}
@@ -176,7 +176,7 @@
                 <AuInput
                   id="values"
                   required="required"
-                  @value={{this.newValue}}
+                  value={{this.newValue}}
                   @width="block"
                   {{on "input" this.updateNewValue}}
                 />

--- a/app/components/content-check.hbs
+++ b/app/components/content-check.hbs
@@ -1,1 +1,3 @@
-<AuToggleSwitch @label={{t 'utility.valid-content'}} @disabled={{false}} @checked={{@concept.valid}} @onChange={{perform this.update}}/>
+<AuToggleSwitch @disabled={{false}} @checked={{@concept.valid}} @onChange={{perform this.update}}>
+  {{t 'utility.valid-content'}}
+</AuToggleSwitch>

--- a/app/components/icon-catalog-form.hbs
+++ b/app/components/icon-catalog-form.hbs
@@ -54,7 +54,7 @@
                 @error={{isInvalid}}
                 id="label"
                 required="required"
-                @value={{@icon.label}}
+                value={{@icon.label}}
                 {{on "input" (fn this.setIconValue "label")}}
               />
               {{#if isInvalid}}

--- a/app/components/icon-catalog-form.hbs
+++ b/app/components/icon-catalog-form.hbs
@@ -76,6 +76,7 @@
       <AuButton
         @disabled={{or @icon.error this.isSaving}}
         @loading={{this.isSaving}}
+        @loadingMessage={{t "utility.save"}}
         {{on "click" (perform this.editIconTask)}}
       >
         {{t "utility.save"}}

--- a/app/components/image-input.hbs
+++ b/app/components/image-input.hbs
@@ -17,8 +17,7 @@
     "image-input.helptext"
   }}</AuHelpText>
 
-{{! because of AU bug @medium is part of wrap instead of no-wrap }}
-<div class="flex au-u-flex--wrap@medium au-u-flex--no-wrap full-width">
+<div class="flex au-u-flex--wrap au-u-flex--no-wrap@medium full-width">
   <FileUploader
     @accept={{"image/jpeg,image/jpg,image/png,image/svg+xml"}}
     @onFileSet={{this.setImageUpload}}

--- a/app/components/page-loader.hbs
+++ b/app/components/page-loader.hbs
@@ -1,0 +1,7 @@
+<AuLoader class="au-o-region-large">
+  {{#if (has-block)}}
+    {{yield}}
+  {{else}}
+    {{t "utility.loading"}}
+  {{/if}}
+</AuLoader>

--- a/app/components/road-marking-form.hbs
+++ b/app/components/road-marking-form.hbs
@@ -99,6 +99,7 @@
       <AuButton
         @disabled={{or @roadMarkingConcept.error this.isSaving}}
         @loading={{this.isSaving}}
+        @loadingMessage={{t "utility.save"}}
         {{on "click" (perform this.editRoadMarkingConceptTask)}}
       >
         {{t "utility.save"}}

--- a/app/components/road-marking-form.hbs
+++ b/app/components/road-marking-form.hbs
@@ -77,7 +77,7 @@
                 class="u-min-h-20"
                 id="meaning"
                 required="required"
-                @value={{@roadMarkingConcept.meaning}}
+                value={{@roadMarkingConcept.meaning}}
                 {{on "input" (fn this.setRoadMarkingConceptValue "meaning")}}
               />
               {{#if isInvalid}}

--- a/app/components/road-marking-form.hbs
+++ b/app/components/road-marking-form.hbs
@@ -51,7 +51,7 @@
                 @error={{isInvalid}}
                 id="road-marking-concept-code"
                 required="required"
-                @value={{@roadMarkingConcept.label}}
+                value={{@roadMarkingConcept.label}}
                 {{on "input" (fn this.setRoadMarkingConceptValue "label")}}
               />
               {{#if isInvalid}}

--- a/app/components/road-sign-form.hbs
+++ b/app/components/road-sign-form.hbs
@@ -54,7 +54,7 @@
                 @error={{isInvalid}}
                 id="label"
                 required="required"
-                @value={{@roadSignConcept.label}}
+                value={{@roadSignConcept.label}}
                 {{on "input" (fn this.setRoadSignConceptValue "label")}}
               />
               {{#if isInvalid}}

--- a/app/components/road-sign-form.hbs
+++ b/app/components/road-sign-form.hbs
@@ -80,7 +80,7 @@
                 class="u-min-h-20"
                 id="meaning"
                 required="required"
-                @value={{@roadSignConcept.meaning}}
+                value={{@roadSignConcept.meaning}}
                 {{on "input" (fn this.setRoadSignConceptValue "meaning")}}
               />
               {{#if isInvalid}}

--- a/app/components/road-sign-form.hbs
+++ b/app/components/road-sign-form.hbs
@@ -193,6 +193,7 @@
       <AuButton
         @disabled={{or @roadSignConcept.error this.isSaving}}
         @loading={{this.isSaving}}
+        @loadingMessage={{t "utility.save"}}
         {{on "click" (perform this.editRoadSignConceptTask)}}
       >
         {{t "utility.save"}}

--- a/app/components/road-sign/shape-select.hbs
+++ b/app/components/road-sign/shape-select.hbs
@@ -124,10 +124,10 @@
                 @disabled={{(or
                   (not this.dimension.unit) (not this.dimension.kind)
                 )}}
-                @type="number"
+                type="number"
                 id="label"
                 required="required"
-                @value={{this.dimension.value}}
+                value={{this.dimension.value}}
               />
             </div>
           {{/let}}

--- a/app/components/traffic-light-form.hbs
+++ b/app/components/traffic-light-form.hbs
@@ -55,7 +55,7 @@
                 @error={{isInvalid}}
                 id="traffic-light-concept-code"
                 required="required"
-                @value={{@trafficLightConcept.label}}
+                value={{@trafficLightConcept.label}}
                 {{on "input" (fn this.setTrafficLightConceptValue "label")}}
               />
               {{#if isInvalid}}

--- a/app/components/traffic-light-form.hbs
+++ b/app/components/traffic-light-form.hbs
@@ -104,6 +104,7 @@
       <AuButton
         @disabled={{or @trafficLightConcept.error this.isSaving}}
         @loading={{this.isSaving}}
+        @loadingMessage={{t "utility.save"}}
         form="edit-traffic-light-concept-form"
         {{on "click" (perform this.editTrafficLightConceptTask)}}
       >

--- a/app/components/traffic-light-form.hbs
+++ b/app/components/traffic-light-form.hbs
@@ -81,7 +81,7 @@
                 class="u-min-h-20"
                 id="meaning"
                 required="required"
-                @value={{@trafficLightConcept.meaning}}
+                value={{@trafficLightConcept.meaning}}
                 {{on "input" (fn this.setTrafficLightConceptValue "meaning")}}
               />
               {{#if isInvalid}}

--- a/app/components/traffic-measure/index.hbs
+++ b/app/components/traffic-measure/index.hbs
@@ -213,6 +213,7 @@
       <AuButton
         {{on "click" (perform this.save)}}
         @loading={{if this.save.isRunning true false}}
+        @loadingMessage={{t "traffic-measure-concept.crud.save"}}
         @disabled={{if this.save.isRunning true false}}
       >
         {{t "traffic-measure-concept.crud.save"}}

--- a/app/components/traffic-measure/index.hbs
+++ b/app/components/traffic-measure/index.hbs
@@ -79,7 +79,7 @@
           @width="block"
           {{on "input" this.updateTemplate}}
           {{on "input" this.parseTemplate}}
-          @value={{this.template.value}}
+          value={{this.template.value}}
           style="resize: none; height: 200px;"
           class="au-u-margin-bottom-small"
         />

--- a/app/components/traffic-measure/instruction-entry.hbs
+++ b/app/components/traffic-measure/instruction-entry.hbs
@@ -7,7 +7,7 @@
   <td class="w-px au-u-padding-right-small">
     <AuButton
       @icon="drag"
-      @skin="tertiary"
+      @skin="link"
       @hideText={{true}}
       class="au-c-button--drag"
     >

--- a/app/components/variable-signage-selector.hbs
+++ b/app/components/variable-signage-selector.hbs
@@ -1,6 +1,7 @@
 <AuToggleSwitch
-  @label={{t "traffic-measure-concept.attr.variable-signage"}}
   @disabled={{false}}
   @checked={{@concept.variableSignage}}
   @onChange={{this.update}}
-/>
+>
+  {{t "traffic-measure-concept.attr.variable-signage"}}
+</AuToggleSwitch>

--- a/app/modifiers/auto-focus.ts
+++ b/app/modifiers/auto-focus.ts
@@ -1,0 +1,65 @@
+import Modifier from 'ember-modifier';
+import { next, scheduleOnce } from '@ember/runloop';
+
+// This modifier is a copy of the `@zestia/ember-auto-focus` addon (v5.2.1): https://github.com/zestia/ember-auto-focus/blob/973e00749e6c4e9ab443b3bee08fbf7937a5bb4b/addon/modifiers/auto-focus.js
+// We inline the implementation since they no longer publish to npm and the implementation is very small anyways.
+// TODO: We should re-evaluate the usage of this since it has accessibility implications and we might not need this modifier in the future.
+
+interface Signature {
+  Element: HTMLElement;
+  Args: {
+    Positional: [selector?: string];
+    Named: {
+      disabled?: boolean;
+    } & FocusOptions;
+  };
+}
+
+export default class AutoFocusModifier extends Modifier<Signature> {
+  didSetup = false;
+
+  modify(
+    element: Signature['Element'],
+    positional: Signature['Args']['Positional'],
+    named: Signature['Args']['Named'],
+  ) {
+    let targetElement: HTMLElement | null = element;
+    if (this.didSetup) {
+      return;
+    }
+
+    this.didSetup = true;
+
+    const { disabled } = named;
+
+    if (disabled) {
+      return;
+    }
+
+    const [selector] = positional;
+
+    if (selector) {
+      targetElement = element.querySelector(selector);
+    }
+
+    if (!targetElement) {
+      return;
+    }
+
+    scheduleOnce('afterRender', this, afterRender, targetElement, named);
+  }
+}
+
+function afterRender(element: HTMLElement, options?: FocusOptions) {
+  if (element.contains(document.activeElement)) {
+    return;
+  }
+
+  focus(element, options);
+}
+
+function focus(element: HTMLElement, options?: FocusOptions) {
+  element.dataset.programmaticallyFocused = 'true';
+  element.focus(options);
+  next(() => delete element.dataset.programmaticallyFocused);
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -22,36 +22,36 @@
 
 
 // SETTINGS
-@import "ember-appuniversum/a-settings";
+@import "@appuniversum/ember-appuniversum/styles/a-settings";
 
 // TOOLS
-@import "ember-appuniversum/a-tools";
+@import "@appuniversum/ember-appuniversum/styles/a-tools";
 
 
 // GENERIC
-@import "ember-appuniversum/a-generic";
+@import "@appuniversum/ember-appuniversum/styles/a-generic";
 
 // ELEMENTS
-@import "ember-appuniversum/a-elements";
+@import "@appuniversum/ember-appuniversum/styles/a-elements";
 
 
 // OBJECTS
-@import "ember-appuniversum/a-objects";
+@import "@appuniversum/ember-appuniversum/styles/a-objects";
 
 
 // COMPONENTS
-@import "ember-appuniversum/a-components";
+@import "@appuniversum/ember-appuniversum/styles/a-components";
 @import "breadcrumbs";
 @import "input-file";
 @import "thumbnail";
 
 
 // PLUGINS
-@import "ember-appuniversum/a-plugins";
+@import "@appuniversum/ember-appuniversum/styles/a-plugins";
 
 
 // UTILITIES
 $au-flex-utilities-responsive: true;
-@import "ember-appuniversum/a-utilities";
+@import "@appuniversum/ember-appuniversum/styles/a-utilities";
 @import "u-heights";
 @import "shame";

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -52,6 +52,7 @@
 
 // UTILITIES
 $au-flex-utilities-responsive: true;
+$au-flex-utilities-reverse-responsive-breakpoints: true;
 @import "@appuniversum/ember-appuniversum/styles/a-utilities";
 @import "u-heights";
 @import "shame";

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -2,7 +2,7 @@
 <AuModalContainer/>
 <AuApp class='{{if this.showEnvironment "au-c-app--environment"}}'>
   {{#if this.showEnvironment}}
-    <EnvironmentBanner 
+    <EnvironmentBanner
       @applicationName='{{t "utility.app-name"}}'
       @environmentName={{this.environmentName}}
     />
@@ -10,8 +10,8 @@
   <AuMainHeader @brandLink="https://www.vlaanderen.be/nl" @homeRoute="index" @appTitle={{t "utility.app-name"}}>
       {{#if this.session.isAuthenticated}}
         {{!-- template-lint-disable require-context-role --}}
-        <AuButton @skin="tertiary" role="menuitem" {{on "click" this.logout}}>
-          <AuIcon @icon="logout" @alignment="left" />{{t "utility.logout"}}
+        <AuButton @icon="logout" @skin="link" role="menuitem" {{on "click" this.logout}}>
+          {{t "utility.logout"}}
         </AuButton>
       {{else}}
         <AuLink @route="login">

--- a/app/templates/codelists-management/edit-loading.hbs
+++ b/app/templates/codelists-management/edit-loading.hbs
@@ -6,4 +6,4 @@
   </Group>
 </AuToolbar>
 
-<AuLoader @size="large" />
+<AuLoader @padding="large" />

--- a/app/templates/codelists-management/edit-loading.hbs
+++ b/app/templates/codelists-management/edit-loading.hbs
@@ -6,4 +6,4 @@
   </Group>
 </AuToolbar>
 
-<AuLoader @padding="large" />
+<PageLoader />

--- a/app/templates/codelists-management/index.hbs
+++ b/app/templates/codelists-management/index.hbs
@@ -17,7 +17,7 @@
         {{! Copied from the AuDataTable::TextSearch component since that doesn't support calling actions on input}}
         <div class="au-c-data-table__search codelist-label-search">
           <AuInput
-            @value={{this.label}}
+            value={{this.label}}
             @icon="search"
             @iconAlignment="right"
             placeholder={{t "codelist.crud.label-filter"}}

--- a/app/templates/icon-catalog/index.hbs
+++ b/app/templates/icon-catalog/index.hbs
@@ -17,7 +17,7 @@
         {{! Copied from the AuDataTable::TextSearch component since that doesn't support calling actions on input}}
         <div class="au-c-data-table__search">
           <AuInput
-            @value={{this.code}}
+            value={{this.code}}
             placeholder={{t "icon-catalog.crud.label-filter"}}
             @icon="search"
             @iconAlignment="right"

--- a/app/templates/index-loading.hbs
+++ b/app/templates/index-loading.hbs
@@ -6,9 +6,9 @@
           <AuHeading @skin="2">
             {{t "utility.app-name"}}
           </AuHeading>
-          <AuLoader @padding="small" />
         </div>
       </div>
     </div>
+    <PageLoader />
   </div>
 </div>

--- a/app/templates/index-loading.hbs
+++ b/app/templates/index-loading.hbs
@@ -6,7 +6,7 @@
           <AuHeading @skin="2">
             {{t "utility.app-name"}}
           </AuHeading>
-          <AuLoader @size="small" />
+          <AuLoader @padding="small" />
         </div>
       </div>
     </div>

--- a/app/templates/loading.hbs
+++ b/app/templates/loading.hbs
@@ -1,2 +1,2 @@
 <NavigationBar />
-<AuLoader @padding="large" />
+<PageLoader />

--- a/app/templates/loading.hbs
+++ b/app/templates/loading.hbs
@@ -1,2 +1,2 @@
 <NavigationBar />
-<AuLoader @size="large" />
+<AuLoader @padding="large" />

--- a/app/templates/mock-login.hbs
+++ b/app/templates/mock-login.hbs
@@ -10,7 +10,9 @@
             }}</AuHeading>
           <MockLogin as |login|>
             {{#if login.isLoading}}
-              <AuLoader />
+              <AuLoader @hideMessage={{true}} @centered={{false}}>
+                {{t "utility.loading"}}
+              </AuLoader>
             {{else}}
               {{#if login.errorMessage}}
                 {{login.errorMessage}}

--- a/app/templates/mock-login.hbs
+++ b/app/templates/mock-login.hbs
@@ -22,7 +22,7 @@
                       class='au-o-box au-o-box--small au-c-card au-u-margin-bottom-small'
                     >
                       <AuButton
-                        @skin='tertiary'
+                        @skin='link'
                         {{on
                           'click'
                           (fn login.login entity.account.id entity.group.id)

--- a/app/templates/road-marking-concepts/edit-loading.hbs
+++ b/app/templates/road-marking-concepts/edit-loading.hbs
@@ -6,4 +6,4 @@
   </Group>
 </AuToolbar>
 
-<AuLoader @size="large" />
+<AuLoader @padding="large" />

--- a/app/templates/road-marking-concepts/edit-loading.hbs
+++ b/app/templates/road-marking-concepts/edit-loading.hbs
@@ -6,4 +6,4 @@
   </Group>
 </AuToolbar>
 
-<AuLoader @padding="large" />
+<PageLoader />

--- a/app/templates/road-marking-concepts/index.hbs
+++ b/app/templates/road-marking-concepts/index.hbs
@@ -17,7 +17,7 @@
         {{! Copied from the AuDataTable::TextSearch component since that doesn't support calling actions on input}}
         <div class="au-c-data-table__search road-marking-code-search">
           <AuInput
-            @value={{this.code}}
+            value={{this.label}}
             placeholder={{t "road-marking-concept.crud.label-filter"}}
             @icon="search"
             @iconAlignment="right"
@@ -26,7 +26,7 @@
         </div>
         <div class="au-c-data-table__search road-marking-meaning-search">
           <AuInput
-            @value={{this.meaning}}
+            value={{this.meaning}}
             placeholder={{t "road-marking-concept.crud.meaning-filter"}}
             @icon="search"
             @iconAlignment="right"

--- a/app/templates/road-marking-concepts/road-marking-concept.hbs
+++ b/app/templates/road-marking-concepts/road-marking-concept.hbs
@@ -170,7 +170,7 @@
           </AuToolbar>
           <div class="au-c-data-table__search">
             <AuInput
-              @value={{this.relatedRoadMarkingCodeFilter}}
+              value={{this.relatedRoadMarkingCodeFilter}}
               placeholder={{t "related-road-marking.filter.label"}}
               @icon="search"
               @iconAlignment="right"
@@ -309,7 +309,7 @@
           </AuToolbar>
           <div class="au-c-data-table__search">
             <AuInput
-              @value={{this.relatedTrafficLightCodeFilter}}
+              value={{this.relatedTrafficLightCodeFilter}}
               placeholder={{t "related-traffic-light.filter.label"}}
               @icon="search"
               @iconAlignment="right"

--- a/app/templates/road-sign-concepts/edit-loading.hbs
+++ b/app/templates/road-sign-concepts/edit-loading.hbs
@@ -6,4 +6,4 @@
   </Group>
 </AuToolbar>
 
-<AuLoader @size="large" />
+<AuLoader @padding="large" />

--- a/app/templates/road-sign-concepts/edit-loading.hbs
+++ b/app/templates/road-sign-concepts/edit-loading.hbs
@@ -6,4 +6,4 @@
   </Group>
 </AuToolbar>
 
-<AuLoader @padding="large" />
+<PageLoader />

--- a/app/templates/road-sign-concepts/index.hbs
+++ b/app/templates/road-sign-concepts/index.hbs
@@ -17,7 +17,7 @@
         {{! Copied from the AuDataTable::TextSearch component since that doesn't support calling actions on input}}
         <div class="au-c-data-table__search road-sign-code-search">
           <AuInput
-            @value={{this.label}}
+            value={{this.label}}
             placeholder={{t "road-sign-concept.crud.label-filter"}}
             @icon="search"
             @iconAlignment="right"
@@ -26,7 +26,7 @@
         </div>
         <div class="au-c-data-table__search road-sign-meaning-search">
           <AuInput
-            @value={{this.meaning}}
+            value={{this.meaning}}
             placeholder={{t "road-sign-concept.crud.meaning-filter"}}
             @icon="search"
             @iconAlignment="right"

--- a/app/templates/road-sign-concepts/road-sign-concept.hbs
+++ b/app/templates/road-sign-concepts/road-sign-concept.hbs
@@ -351,7 +351,7 @@
           </AuToolbar>
           <div class="au-c-data-table__search">
             <AuInput
-              @value={{this.subSignCodeFilter}}
+              value={{this.subSignCodeFilter}}
               placeholder={{t "sub-sign.filter.label"}}
               @icon="search"
               @iconAlignment="right"
@@ -535,7 +535,7 @@
           </AuToolbar>
           <div class="au-c-data-table__search">
             <AuInput
-              @value={{this.relatedRoadMarkingCodeFilter}}
+              value={{this.relatedRoadMarkingCodeFilter}}
               placeholder={{t "related-road-marking.filter.label"}}
               @icon="search"
               @iconAlignment="right"
@@ -607,7 +607,7 @@
           </AuToolbar>
           <div class="au-c-data-table__search">
             <AuInput
-              @value={{this.relatedTrafficLightCodeFilter}}
+              value={{this.relatedTrafficLightCodeFilter}}
               placeholder={{t "related-traffic-light.filter.label"}}
               @icon="search"
               @iconAlignment="right"

--- a/app/templates/traffic-light-concepts/edit-loading.hbs
+++ b/app/templates/traffic-light-concepts/edit-loading.hbs
@@ -6,4 +6,4 @@
   </Group>
 </AuToolbar>
 
-<AuLoader @size="large" />
+<AuLoader @padding="large" />

--- a/app/templates/traffic-light-concepts/edit-loading.hbs
+++ b/app/templates/traffic-light-concepts/edit-loading.hbs
@@ -6,4 +6,4 @@
   </Group>
 </AuToolbar>
 
-<AuLoader @padding="large" />
+<PageLoader />

--- a/app/templates/traffic-light-concepts/index.hbs
+++ b/app/templates/traffic-light-concepts/index.hbs
@@ -17,16 +17,16 @@
         {{! Copied from the AuDataTable::TextSearch component since that doesn't support calling actions on input}}
         <div class="au-c-data-table__search traffic-light-code-search">
           <AuInput
-            @value={{this.label}}
+            value={{this.label}}
             placeholder={{t "traffic-light-concept.crud.label-filter"}}
             @icon="search"
             @iconAlignment="right"
-            {{on "input" (perform this.updateSearchFilterTask "code")}}
+            {{on "input" (perform this.updateSearchFilterTask "label")}}
           />
         </div>
         <div class="au-c-data-table__search traffic-light-meaning-search">
           <AuInput
-            @value={{this.meaning}}
+            value={{this.meaning}}
             placeholder={{t "traffic-light-concept.crud.meaning-filter"}}
             @icon="search"
             @iconAlignment="right"

--- a/app/templates/traffic-light-concepts/traffic-light-concept.hbs
+++ b/app/templates/traffic-light-concepts/traffic-light-concept.hbs
@@ -237,7 +237,7 @@
           </AuToolbar>
           <div class="au-c-data-table__search">
             <AuInput
-              @value={{this.relatedRoadMarkingCodeFilter}}
+              value={{this.relatedRoadMarkingCodeFilter}}
               placeholder={{t "related-road-marking.filter.label"}}
               @icon="search"
               @iconAlignment="right"
@@ -308,7 +308,7 @@
           </AuToolbar>
           <div class="au-c-data-table__search">
             <AuInput
-              @value={{this.relatedTrafficLightCodeFilter}}
+              value={{this.relatedTrafficLightCodeFilter}}
               placeholder={{t "related-traffic-light.filter.label"}}
               @icon="search"
               @iconAlignment="right"

--- a/app/templates/traffic-measure-concepts/edit-loading.hbs
+++ b/app/templates/traffic-measure-concepts/edit-loading.hbs
@@ -6,4 +6,4 @@
   </Group>
 </AuToolbar>
 
-<AuLoader @size="large" />
+<AuLoader @padding="large" />

--- a/app/templates/traffic-measure-concepts/edit-loading.hbs
+++ b/app/templates/traffic-measure-concepts/edit-loading.hbs
@@ -6,4 +6,4 @@
   </Group>
 </AuToolbar>
 
-<AuLoader @padding="large" />
+<PageLoader />

--- a/app/templates/traffic-measure-concepts/index.hbs
+++ b/app/templates/traffic-measure-concepts/index.hbs
@@ -17,7 +17,7 @@
         {{! Copied from the AuDataTable::TextSearch component since that doesn't support calling actions on input}}
         <div class="au-c-data-table__search traffic-light-code-search">
           <AuInput
-            @value={{this.label}}
+            value={{this.label}}
             placeholder={{t "traffic-measure-concept.attr.label"}}
             @icon="search"
             @iconAlignment="right"

--- a/config/environment.js
+++ b/config/environment.js
@@ -10,7 +10,7 @@ module.exports = function (environment) {
     modulePrefix: 'mow-registry',
     environment,
     rootURL: '/',
-    locationType: 'auto',
+    locationType: 'history',
     sparqlEndpoint: '{{SPARQL_ENDPOINT}}',
     yasgui: {
       // NOTE: look at app/modifiers/yasgui.js when changing this variable

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,12 +5,6 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function (defaults) {
   const app = new EmberApp(defaults, {
     // Add options here
-    sassOptions: {
-      sourceMapEmbed: true,
-      includePaths: [
-        'node_modules/@appuniversum/ember-appuniversum/app/styles',
-      ],
-    },
     'ember-cli-babel': {
       enableTypeScriptTransform: true,
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "joi": "^17.13.3"
       },
       "devDependencies": {
-        "@appuniversum/ember-appuniversum": "^2.18.0",
+        "@appuniversum/ember-appuniversum": "^3.5.0",
         "@babel/eslint-parser": "^7.22.15",
         "@babel/plugin-proposal-decorators": "^7.22.10",
         "@bagaar/ember-breadcrumbs": "^4.1.0",
@@ -27,7 +27,7 @@
         "@ember/test-helpers": "^2.9.4",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
-        "@lblod/ember-environment-banner": "^0.2.0",
+        "@lblod/ember-environment-banner": "^0.5.0",
         "@lblod/ember-mock-login": "^0.7.0",
         "@release-it-plugins/lerna-changelog": "^7.0.0",
         "@tsconfig/ember": "^2.0.0",
@@ -149,41 +149,41 @@
       }
     },
     "node_modules/@appuniversum/ember-appuniversum": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-2.18.0.tgz",
-      "integrity": "sha512-W67tWC3racq9Eq9ziV4heFhAPeoRG0ILPtjKmYwM0BeIQ8k+L6Fp3Vrnh741yQBERNkdAr6F8XQu4G8mNbkBow==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-3.5.0.tgz",
+      "integrity": "sha512-vhDWMLcWvBZmUziXjow/w+vfEW3XTrvhDjS4cQtKjGGHWa6Os6F0e49E8CchgwBCYC9XNCgfqrBWee29dDj1Tg==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.22.10",
+        "@babel/core": "^7.23.2",
         "@duetds/date-picker": "^1.4.0",
         "@embroider/macros": "^1.9.0",
         "@floating-ui/dom": "^1.1.0",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
-        "@zestia/ember-auto-focus": "^4.2.0",
         "ember-auto-import": "^2.6.3",
-        "ember-cli-babel": "^7.26.11",
+        "ember-cli-babel": "^8.2.0",
         "ember-cli-htmlbars": "^6.3.0",
-        "ember-concurrency": "2.x || ^3.1.0",
+        "ember-concurrency": "^3.1.0",
         "ember-data-table": "^2.1.0",
-        "ember-file-upload": "^7.0.3",
+        "ember-file-upload": "^8.4.0",
         "ember-focus-trap": "^1.1.0",
-        "ember-modifier": "^3.2.7",
-        "ember-template-imports": "^3.4.2",
+        "ember-modifier": "^4.1.0",
+        "ember-template-imports": "^4.1.1",
         "ember-test-selectors": "^6.0.0",
-        "ember-truth-helpers": "^3.1.1",
-        "inputmask": "^5.0.7",
+        "ember-truth-helpers": "^3.1.1 || ^4.0.3",
+        "inputmask": "^5.0.9-beta.45",
         "merge-anything": "^5.1.3",
         "tracked-toolbox": "^2.0.0"
       },
       "engines": {
-        "node": "14.* || 16.* || >= 18"
+        "node": ">= 18"
       },
       "optionalDependencies": {
         "ember-power-select": "2.x || 3.x || 4.x || 5.x || 6.x || 7.x"
       },
       "peerDependencies": {
-        "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
+        "ember-source": "^4.12.0 || ^5.0.0",
+        "tracked-built-ins": "^3.3.0"
       }
     },
     "node_modules/@appuniversum/ember-appuniversum/node_modules/async-disk-cache": {
@@ -202,6 +202,50 @@
       },
       "engines": {
         "node": "8.* || >= 10.*"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/babel-plugin-module-resolver": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.2.tgz",
+      "integrity": "sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg==",
+      "dev": true,
+      "dependencies": {
+        "find-babel-config": "^2.1.1",
+        "glob": "^9.3.3",
+        "pkg-up": "^3.1.0",
+        "reselect": "^4.1.7",
+        "resolve": "^1.22.8"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/broccoli-babel-transpiler": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-8.0.0.tgz",
+      "integrity": "sha512-3HEp3flvasUKJGWERcrPgM1SWvHJ0O/fmbEtY9L4kDyMSnqjY6hTYvNvgWCIgbwXAYAUlZP0vjAQsmyLNGLwFw==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-persistent-filter": "^3.0.0",
+        "clone": "^2.1.2",
+        "hash-for-dep": "^1.4.7",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.9",
+        "json-stable-stringify": "^1.0.1",
+        "rsvp": "^4.8.4",
+        "workerpool": "^6.0.2"
+      },
+      "engines": {
+        "node": "16.* || >= 18"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.17.9"
       }
     },
     "node_modules/@appuniversum/ember-appuniversum/node_modules/broccoli-persistent-filter": {
@@ -278,50 +322,88 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/@appuniversum/ember-appuniversum/node_modules/ember-concurrency": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/ember-concurrency/-/ember-concurrency-2.3.7.tgz",
-      "integrity": "sha512-sz6sTIXN/CuLb5wdpauFa+rWXuvXXSnSHS4kuNzU5GSMDX1pLBWSuovoUk61FUe6CYRqBmT1/UushObwBGickQ==",
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/ember-cli-babel": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-8.2.0.tgz",
+      "integrity": "sha512-8H4+jQElCDo6tA7CamksE66NqBXWs7VNpS3a738L9pZCjg2kXIX4zoyHzkORUqCtr0Au7YsCnrlAMi1v2ALo7A==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/types": "^7.12.13",
-        "@glimmer/tracking": "^1.0.4",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
-        "ember-cli-htmlbars": "^5.7.1",
-        "ember-compatibility-helpers": "^1.2.0",
-        "ember-destroyable-polyfill": "^2.0.2"
-      },
-      "engines": {
-        "node": "10.* || 12.* || 14.* || >= 16"
-      }
-    },
-    "node_modules/@appuniversum/ember-appuniversum/node_modules/ember-concurrency/node_modules/ember-cli-htmlbars": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
-      "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
-      "dev": true,
-      "dependencies": {
-        "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
-        "broccoli-debug": "^0.6.5",
-        "broccoli-persistent-filter": "^3.1.2",
-        "broccoli-plugin": "^4.0.3",
-        "common-tags": "^1.8.0",
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/plugin-proposal-class-properties": "^7.16.5",
+        "@babel/plugin-proposal-decorators": "^7.20.13",
+        "@babel/plugin-proposal-private-methods": "^7.16.5",
+        "@babel/plugin-proposal-private-property-in-object": "^7.20.5",
+        "@babel/plugin-transform-class-static-block": "^7.22.11",
+        "@babel/plugin-transform-modules-amd": "^7.20.11",
+        "@babel/plugin-transform-runtime": "^7.13.9",
+        "@babel/plugin-transform-typescript": "^7.20.13",
+        "@babel/preset-env": "^7.20.2",
+        "@babel/runtime": "7.12.18",
+        "amd-name-resolver": "^1.3.1",
+        "babel-plugin-debug-macros": "^0.3.4",
+        "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
+        "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
+        "babel-plugin-module-resolver": "^5.0.0",
+        "broccoli-babel-transpiler": "^8.0.0",
+        "broccoli-debug": "^0.6.4",
+        "broccoli-funnel": "^3.0.8",
+        "broccoli-source": "^3.0.1",
+        "calculate-cache-key-for-tree": "^2.0.0",
+        "clone": "^2.1.2",
         "ember-cli-babel-plugin-helpers": "^1.1.1",
         "ember-cli-version-checker": "^5.1.2",
-        "fs-tree-diff": "^2.0.1",
-        "hash-for-dep": "^1.5.1",
-        "heimdalljs-logger": "^0.1.10",
-        "json-stable-stringify": "^1.0.1",
-        "semver": "^7.3.4",
-        "silent-error": "^1.1.1",
-        "strip-bom": "^4.0.0",
-        "walk-sync": "^2.2.0"
+        "ensure-posix-path": "^1.0.2",
+        "resolve-package-path": "^4.0.3",
+        "semver": "^7.3.8"
       },
       "engines": {
-        "node": "10.* || >= 12.*"
+        "node": "16.* || 18.* || >= 20"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.0"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/ember-modifier": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-4.2.0.tgz",
+      "integrity": "sha512-BJ48eTEGxD8J7+lofwVmee7xDgNDgpr5dd6+MSu4gk+I6xb35099RMNorXY5hjjwMJEyi/IRR6Yn3M7iJMz8Zw==",
+      "dev": true,
+      "dependencies": {
+        "@embroider/addon-shim": "^1.8.7",
+        "decorator-transforms": "^2.0.0",
+        "ember-cli-normalize-entity-name": "^1.0.0",
+        "ember-cli-string-utils": "^1.1.0"
+      },
+      "peerDependencies": {
+        "ember-source": "^3.24 || >=4.0"
+      },
+      "peerDependenciesMeta": {
+        "ember-source": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/ember-template-imports": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ember-template-imports/-/ember-template-imports-4.1.1.tgz",
+      "integrity": "sha512-mnbL3hjo/Ctg7rkBtuYkBRJUn5bDYRQCEZQxmNozRnfoEp2RLSbT6SFJRAFDYXT2OrY+8i821S4kPL1i0QuGIw==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-stew": "^3.0.0",
+        "content-tag": "^2.0.1",
+        "ember-cli-version-checker": "^5.1.2"
+      },
+      "engines": {
+        "node": "16.* || >= 18"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/find-babel-config": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-2.1.2.tgz",
+      "integrity": "sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^2.2.3"
       }
     },
     "node_modules/@appuniversum/ember-appuniversum/node_modules/fs-tree-diff": {
@@ -338,6 +420,24 @@
       },
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/glob": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@appuniversum/ember-appuniversum/node_modules/istextorbinary": {
@@ -357,6 +457,21 @@
         "url": "https://bevry.me/fund"
       }
     },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/minimatch": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@appuniversum/ember-appuniversum/node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -364,6 +479,15 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@appuniversum/ember-appuniversum/node_modules/mkdirp": {
@@ -382,6 +506,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
@@ -393,6 +518,49 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@appuniversum/ember-appuniversum/node_modules/rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
@@ -402,130 +570,42 @@
         "node": "6.* || >= 7.*"
       }
     },
-    "node_modules/@appuniversum/ember-appuniversum/node_modules/strip-bom": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@appuniversum/ember-appuniversum/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
       "dependencies": {
-        "@babel/highlight": "^7.22.13",
-        "chalk": "^2.4.2"
+        "@babel/highlight": "^7.24.7",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-    },
-    "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@babel/compat-data": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.9.tgz",
-      "integrity": "sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
+      "integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.22.17",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.17.tgz",
-      "integrity": "sha512-2EENLmhpwplDux5PSsZnSbnSkB3tZ6QTksgO25xwEL7pIDcNOMhF5v/s6RzwjMZzZzw9Ofc30gHv5ChCC8pifQ==",
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
+      "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.22.15",
-        "@babel/helper-compilation-targets": "^7.22.15",
-        "@babel/helper-module-transforms": "^7.22.17",
-        "@babel/helpers": "^7.22.15",
-        "@babel/parser": "^7.22.16",
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.22.17",
-        "@babel/types": "^7.22.17",
-        "convert-source-map": "^1.7.0",
+        "@babel/code-frame": "^7.24.7",
+        "@babel/generator": "^7.25.0",
+        "@babel/helper-compilation-targets": "^7.25.2",
+        "@babel/helper-module-transforms": "^7.25.2",
+        "@babel/helpers": "^7.25.0",
+        "@babel/parser": "^7.25.0",
+        "@babel/template": "^7.25.0",
+        "@babel/traverse": "^7.25.2",
+        "@babel/types": "^7.25.2",
+        "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.2.3",
@@ -538,6 +618,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
       }
+    },
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
@@ -584,13 +669,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.6.tgz",
+      "integrity": "sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==",
       "dependencies": {
-        "@babel/types": "^7.23.0",
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "@jridgewell/trace-mapping": "^0.3.17",
+        "@babel/types": "^7.25.6",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
       },
       "engines": {
@@ -598,11 +683,11 @@
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
-      "integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
+      "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -621,13 +706,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
-      "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz",
+      "integrity": "sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==",
       "dependencies": {
-        "@babel/compat-data": "^7.22.9",
-        "@babel/helper-validator-option": "^7.22.15",
-        "browserslist": "^4.21.9",
+        "@babel/compat-data": "^7.25.2",
+        "@babel/helper-validator-option": "^7.24.8",
+        "browserslist": "^4.23.1",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -644,18 +729,16 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.11.tgz",
-      "integrity": "sha512-y1grdYL4WzmUDBRGK0pDbIoFd7UZKoDurDzWEoNMYoj1EL+foGRQNyPWDcC+YyegN5y1DUsFFmzjGijB3nSVAQ==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.4.tgz",
+      "integrity": "sha512-ro/bFs3/84MDgDmMwbcHgDa8/E6J3QKNTk4xJJnVeFtGE+tL0K26E3pNxhYz2b67fJpt7Aphw5XcploKXuCvCQ==",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-function-name": "^7.22.5",
-        "@babel/helper-member-expression-to-functions": "^7.22.5",
-        "@babel/helper-optimise-call-expression": "^7.22.5",
-        "@babel/helper-replace-supers": "^7.22.9",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/helper-annotate-as-pure": "^7.24.7",
+        "@babel/helper-member-expression-to-functions": "^7.24.8",
+        "@babel/helper-optimise-call-expression": "^7.24.7",
+        "@babel/helper-replace-supers": "^7.25.0",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
+        "@babel/traverse": "^7.25.4",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -755,37 +838,38 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.22.5.tgz",
-      "integrity": "sha512-aBiH1NKMG0H2cGZqspNvsaBe6wNGjbJjuLy29aU+eDZjSbbN53BaxlpB02xm9v34pLTZ1nIQPFYn2qMZoa5BQQ==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.8.tgz",
+      "integrity": "sha512-LABppdt+Lp/RlBxqrh4qgf1oEH/WxdzQNDJIu5gC/W1GyvPVrOBiItmmM8wan2fm4oYqFuFfkXmlGpLQhPY8CA==",
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/traverse": "^7.24.8",
+        "@babel/types": "^7.24.8"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
+      "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
       "dependencies": {
-        "@babel/types": "^7.22.15"
+        "@babel/traverse": "^7.24.7",
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.22.17",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.17.tgz",
-      "integrity": "sha512-XouDDhQESrLHTpnBtCKExJdyY4gJCdrvH2Pyv8r8kovX2U8G0dRUOT45T9XlbLtuu9CLXP15eusnkprhoPV5iQ==",
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.2.tgz",
+      "integrity": "sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==",
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-module-imports": "^7.22.15",
-        "@babel/helper-simple-access": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/helper-validator-identifier": "^7.22.15"
+        "@babel/helper-module-imports": "^7.24.7",
+        "@babel/helper-simple-access": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.24.7",
+        "@babel/traverse": "^7.25.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -795,20 +879,20 @@
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.22.5.tgz",
-      "integrity": "sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.24.7.tgz",
+      "integrity": "sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==",
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
+      "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -831,13 +915,13 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.22.9.tgz",
-      "integrity": "sha512-LJIKvvpgPOPUThdYqcX6IXRuIcTkcAub0IaDRGCZH0p5GPUp7PhRU9QVgFcDDd51BaPkk77ZjqFwh6DZTAEmGg==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.0.tgz",
+      "integrity": "sha512-q688zIvQVYtZu+i2PsdIu/uWGRpfxzr5WESsfpShfZECkO+d2o+WROWezCi/Q6kJ0tfPa5+pUGUlfx2HhrA3Bg==",
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-member-expression-to-functions": "^7.22.5",
-        "@babel/helper-optimise-call-expression": "^7.22.5"
+        "@babel/helper-member-expression-to-functions": "^7.24.8",
+        "@babel/helper-optimise-call-expression": "^7.24.7",
+        "@babel/traverse": "^7.25.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -847,22 +931,24 @@
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
+      "integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/traverse": "^7.24.7",
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.22.5.tgz",
-      "integrity": "sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.24.7.tgz",
+      "integrity": "sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==",
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/traverse": "^7.24.7",
+        "@babel/types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -880,25 +966,25 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
+      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
-      "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
+      "integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -918,26 +1004,26 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.15.tgz",
-      "integrity": "sha512-7pAjK0aSdxOwR+CcYAqgWOGy5dcfvzsTIfFTb2odQqW47MDfv14UaJDY6eng8ylM2EaeKXdxaSWESbkmaQHTmw==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.6.tgz",
+      "integrity": "sha512-Xg0tn4HcfTijTwfDwYlvVCl43V6h4KyVVX2aEm4qdO/PC6L2YvzLHFdmxhoeSA3eslcE6+ZVXHgWwopXYLNq4Q==",
       "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/template": "^7.25.0",
+        "@babel/types": "^7.25.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.13.tgz",
-      "integrity": "sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1008,9 +1094,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
+      "integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
+      "dependencies": {
+        "@babel/types": "^7.25.6"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1337,11 +1426,11 @@
       }
     },
     "node_modules/@babel/plugin-syntax-decorators": {
-      "version": "7.22.10",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.22.10.tgz",
-      "integrity": "sha512-z1KTVemBjnz+kSEilAsI4lbkPOl5TvJH7YDSY1CTIzvLWJ+KHXp+mRe8VPmfnyvqOPqar1V2gid2PleKzRUstQ==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.24.7.tgz",
+      "integrity": "sha512-Ui4uLJJrRV1lb38zg1yYTmRKmiZLiftDEvZN2iq3kd9kUFU+PttmzTbAFC2ucRk/XJmtek6G23gPsuZbhrT8fQ==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.22.5"
+        "@babel/helper-plugin-utils": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1561,6 +1650,23 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-class-static-block": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.24.7.tgz",
+      "integrity": "sha512-HMXK3WbBPpZQufbMG4B46A90PkuuhN9vBCb5T8+VAHqvAqvcLi+2cKoukcpmUYkszLhScU3l1iudhrks3DggRQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.24.7",
+        "@babel/helper-plugin-utils": "^7.24.7",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.0"
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
@@ -2158,32 +2264,29 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
+      "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.24.7",
+        "@babel/parser": "^7.25.0",
+        "@babel/types": "^7.25.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.6.tgz",
+      "integrity": "sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.0",
-        "@babel/types": "^7.23.0",
-        "debug": "^4.1.0",
+        "@babel/code-frame": "^7.24.7",
+        "@babel/generator": "^7.25.6",
+        "@babel/parser": "^7.25.6",
+        "@babel/template": "^7.25.0",
+        "@babel/types": "^7.25.6",
+        "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -2191,12 +2294,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
+      "integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.8",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -3887,16 +3990,45 @@
       }
     },
     "node_modules/@embroider/addon-shim": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/@embroider/addon-shim/-/addon-shim-1.8.6.tgz",
-      "integrity": "sha512-siC9kP78uucEbpDcVyxjkwa76pcs5rVzDVpWO4PDc9EAXRX+pzmUuSTLAK3GztUwx7/PWhz1BenAivqdSvSgfg==",
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/@embroider/addon-shim/-/addon-shim-1.8.9.tgz",
+      "integrity": "sha512-qyN64T1jMHZ99ihlk7VFHCWHYZHLE1DOdHi0J7lmn5waV1DoW7gD8JLi1i7FregzXtKhbDc7shyEmTmWPTs8MQ==",
       "dependencies": {
-        "@embroider/shared-internals": "^2.2.3",
+        "@embroider/shared-internals": "^2.6.0",
         "broccoli-funnel": "^3.0.8",
+        "common-ancestor-path": "^1.0.1",
         "semver": "^7.3.8"
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/@embroider/addon-shim/node_modules/@embroider/shared-internals": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.6.3.tgz",
+      "integrity": "sha512-wyFQNSqN+RZWg5ckqsk0Qfun433aEd70L6sc16sY4FFf/AzDnolmc0t3eR7lkdyxltYSrO5eqkFN7hW7l/glaw==",
+      "dependencies": {
+        "babel-import-util": "^2.0.0",
+        "debug": "^4.3.2",
+        "ember-rfc176-data": "^0.3.17",
+        "fs-extra": "^9.1.0",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.21",
+        "minimatch": "^3.0.4",
+        "resolve-package-path": "^4.0.1",
+        "semver": "^7.3.5",
+        "typescript-memoize": "^1.0.1"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/@embroider/addon-shim/node_modules/babel-import-util": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.1.1.tgz",
+      "integrity": "sha512-3qBQWRjzP9NreSH/YrOEU1Lj5F60+pWSLP0kIdCWxjFHH7pX2YPHIxQ67el4gnMNfYoDxSDGcT0zpVlZ+gVtQA==",
+      "engines": {
+        "node": ">= 12.*"
       }
     },
     "node_modules/@embroider/macros": {
@@ -3939,6 +4071,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.4.0.tgz",
       "integrity": "sha512-pFE05ebenWMC9XAPRjadYCXXb6VmqjkhYN5uqkhPo+VUmMHnx7sZYYxqGjxfVuhC/ghS/BNlOffOCXDOoE7k7g==",
+      "dev": true,
       "dependencies": {
         "babel-import-util": "^2.0.0",
         "debug": "^4.3.2",
@@ -3958,6 +4091,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-2.0.0.tgz",
       "integrity": "sha512-pkWynbLwru0RZmA9iKeQL63+CkkW0RCP3kL5njCtudd6YPUKb5Pa0kL4fb3bmuKn2QDBFwY5mvvhEK/+jv2Ynw==",
+      "dev": true,
       "engines": {
         "node": ">= 12.*"
       }
@@ -4563,13 +4697,13 @@
       "dev": true
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
       "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
         "node": ">=6.0.0"
@@ -4584,9 +4718,9 @@
       }
     },
     "node_modules/@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -4607,12 +4741,12 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
-      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
       "dependencies": {
-        "@jridgewell/resolve-uri": "3.1.0",
-        "@jridgewell/sourcemap-codec": "1.4.14"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@lblod/ember-acmidm-login": {
@@ -4627,241 +4761,22 @@
       }
     },
     "node_modules/@lblod/ember-environment-banner": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-environment-banner/-/ember-environment-banner-0.2.0.tgz",
-      "integrity": "sha512-oiRBR5xgXcjS3wQM322F8BTvrJ9K2f4jCOZPDv7qrTH4vB6ldp5K258UK6zlrA0qLOwpKh7uaEL8xXZe4U2sYA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-environment-banner/-/ember-environment-banner-0.5.0.tgz",
+      "integrity": "sha512-1IqxDS2kPbkH32eZC2YvsIbNWrSAyV5NJWaEC+js1+PZ6q9gbURa8lsXWYYhNbajrOTky4q01QGk76G3D6QzJw==",
       "dev": true,
       "dependencies": {
-        "ember-cli-babel": "^7.26.6",
+        "@embroider/macros": "^1.13.1",
+        "ember-cli-babel": "^7.26.11",
         "ember-cli-dependency-lint": "^2.0.1",
-        "ember-cli-htmlbars": "^5.7.1"
+        "ember-cli-htmlbars": "^6.2.0"
       },
       "engines": {
-        "node": ">= 16"
+        "node": "14.* || 16.* || >= 18"
       },
       "peerDependencies": {
-        "@appuniversum/ember-appuniversum": "^2.0.0"
-      }
-    },
-    "node_modules/@lblod/ember-environment-banner/node_modules/async-disk-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
-      "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "heimdalljs": "^0.2.3",
-        "istextorbinary": "^2.5.1",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^3.0.0",
-        "rsvp": "^4.8.5",
-        "username-sync": "^1.0.2"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/@lblod/ember-environment-banner/node_modules/broccoli-persistent-filter": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
-      "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
-      "dev": true,
-      "dependencies": {
-        "async-disk-cache": "^2.0.0",
-        "async-promise-queue": "^1.0.3",
-        "broccoli-plugin": "^4.0.3",
-        "fs-tree-diff": "^2.0.0",
-        "hash-for-dep": "^1.5.0",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "promise-map-series": "^0.2.1",
-        "rimraf": "^3.0.0",
-        "symlink-or-copy": "^1.0.1",
-        "sync-disk-cache": "^2.0.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@lblod/ember-environment-banner/node_modules/broccoli-plugin": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-      "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-node-api": "^1.7.0",
-        "broccoli-output-wrapper": "^3.2.5",
-        "fs-merger": "^3.2.1",
-        "promise-map-series": "^0.3.0",
-        "quick-temp": "^0.1.8",
-        "rimraf": "^3.0.2",
-        "symlink-or-copy": "^1.3.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@lblod/ember-environment-banner/node_modules/broccoli-plugin/node_modules/promise-map-series": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-      "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-      "dev": true,
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@lblod/ember-environment-banner/node_modules/editions": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
-      "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-      "dev": true,
-      "dependencies": {
-        "errlop": "^2.0.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/@lblod/ember-environment-banner/node_modules/editions/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@lblod/ember-environment-banner/node_modules/ember-cli-htmlbars": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
-      "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
-      "dev": true,
-      "dependencies": {
-        "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
-        "broccoli-debug": "^0.6.5",
-        "broccoli-persistent-filter": "^3.1.2",
-        "broccoli-plugin": "^4.0.3",
-        "common-tags": "^1.8.0",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
-        "ember-cli-version-checker": "^5.1.2",
-        "fs-tree-diff": "^2.0.1",
-        "hash-for-dep": "^1.5.1",
-        "heimdalljs-logger": "^0.1.10",
-        "json-stable-stringify": "^1.0.1",
-        "semver": "^7.3.4",
-        "silent-error": "^1.1.1",
-        "strip-bom": "^4.0.0",
-        "walk-sync": "^2.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@lblod/ember-environment-banner/node_modules/fs-tree-diff": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-      "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-      "dev": true,
-      "dependencies": {
-        "@types/symlink-or-copy": "^1.2.0",
-        "heimdalljs-logger": "^0.1.7",
-        "object-assign": "^4.1.0",
-        "path-posix": "^1.0.0",
-        "symlink-or-copy": "^1.1.8"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/@lblod/ember-environment-banner/node_modules/istextorbinary": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
-      "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-      "dev": true,
-      "dependencies": {
-        "binaryextensions": "^2.1.2",
-        "editions": "^2.2.0",
-        "textextensions": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/@lblod/ember-environment-banner/node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@lblod/ember-environment-banner/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/@lblod/ember-environment-banner/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@lblod/ember-environment-banner/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/@lblod/ember-environment-banner/node_modules/strip-bom": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@lblod/ember-environment-banner/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
+        "@appuniversum/ember-appuniversum": "^2.0.0 || ^3.0.0",
+        "ember-source": "^4.0.0"
       }
     },
     "node_modules/@lblod/ember-mock-login": {
@@ -6977,20 +6892,6 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
-    "node_modules/@zestia/ember-auto-focus": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@zestia/ember-auto-focus/-/ember-auto-focus-4.4.0.tgz",
-      "integrity": "sha512-Oios2kkkOLkaaKAxQl25XNjdhskv3BWpxOgjE/i8ig30uUloepU0i8idByqQdsUmNdPmsMr7sQ8TEZ2W7NAfMg==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.0.1",
-        "ember-modifier": "^3.2.7"
-      },
-      "engines": {
-        "node": "12.* || 14.* || >= 16"
-      }
-    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -8089,13 +7990,23 @@
       }
     },
     "node_modules/babel-plugin-ember-template-compilation": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-2.0.3.tgz",
-      "integrity": "sha512-SIetZD/uCLnzIBTJtzYGc2Q55TPqM5WyjuOgW+Is1W3SZVljlY3JD5Add29hDMs//OvXBWoXfOopQxkfG4/pIA==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-2.2.5.tgz",
+      "integrity": "sha512-NQ2DT0DsYyHVrEpFQIy2U8S91JaKSE8NOSZzMd7KZFJVgA6KodJq3Uj852HcH9LsSfvwppnM+dRo1G8bzTnnFw==",
       "dev": true,
       "dependencies": {
-        "babel-import-util": "^1.3.0"
+        "@glimmer/syntax": "^0.84.3",
+        "babel-import-util": "^3.0.0"
       },
+      "engines": {
+        "node": ">= 12.*"
+      }
+    },
+    "node_modules/babel-plugin-ember-template-compilation/node_modules/babel-import-util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-3.0.0.tgz",
+      "integrity": "sha512-4YNPkuVsxAW5lnSTa6cn4Wk49RX6GAB6vX+M6LqEtN0YePqoFczv1/x0EyLK/o+4E1j9jEuYj5Su7IEPab5JHQ==",
+      "dev": true,
       "engines": {
         "node": ">= 12.*"
       }
@@ -10872,9 +10783,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.10",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
-      "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
+      "version": "4.23.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
+      "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
       "funding": [
         {
           "type": "opencollective",
@@ -10890,10 +10801,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001517",
-        "electron-to-chromium": "^1.4.477",
-        "node-releases": "^2.0.13",
-        "update-browserslist-db": "^1.0.11"
+        "caniuse-lite": "^1.0.30001646",
+        "electron-to-chromium": "^1.5.4",
+        "node-releases": "^2.0.18",
+        "update-browserslist-db": "^1.1.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -11236,9 +11147,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001640",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001640.tgz",
-      "integrity": "sha512-lA4VMpW0PSUrFnkmVuEKBUovSWKhj7puyCg8StBChgu298N1AtuF1sKWEvfDuimSEDbhlb/KqPKC3fs1HbuQUA==",
+      "version": "1.0.30001655",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001655.tgz",
+      "integrity": "sha512-jRGVy3iSGO5Uutn2owlb5gR6qsGngTw9ZTb4ali9f3glshcNmJ2noam4Mo9zia5P9Dk3jNNydy7vQjuE5dQmfg==",
       "funding": [
         {
           "type": "opencollective",
@@ -11855,6 +11766,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/common-ancestor-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
+      "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w=="
+    },
     "node_modules/common-tags": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
@@ -12384,6 +12300,12 @@
         }
       ]
     },
+    "node_modules/content-tag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/content-tag/-/content-tag-2.0.1.tgz",
+      "integrity": "sha512-jxsETSDs5NbNwyiDuIp672fUMhUyu8Qxc5MOBOJOcgW/fQESI6o5K1LBDrnEE7Bh810a685lWEZHTF4jQYGEEw==",
+      "dev": true
+    },
     "node_modules/content-type": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
@@ -12402,7 +12324,8 @@
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
     },
     "node_modules/cookie": {
       "version": "0.5.0",
@@ -13061,6 +12984,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/decorator-transforms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/decorator-transforms/-/decorator-transforms-2.0.0.tgz",
+      "integrity": "sha512-ETfQccGcotK01YJsoB0AGTdUp7kS9jI93mBzrRY5Oyo+bOJfa2UKTSjCNf+iRNwAWBmBKlbiCcyL4tkY4C4dZQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/plugin-syntax-decorators": "^7.23.3",
+        "babel-import-util": "^3.0.0"
+      }
+    },
+    "node_modules/decorator-transforms/node_modules/babel-import-util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/babel-import-util/-/babel-import-util-3.0.0.tgz",
+      "integrity": "sha512-4YNPkuVsxAW5lnSTa6cn4Wk49RX6GAB6vX+M6LqEtN0YePqoFczv1/x0EyLK/o+4E1j9jEuYj5Su7IEPab5JHQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.*"
+      }
+    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -13600,9 +13542,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.520",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.520.tgz",
-      "integrity": "sha512-Frfus2VpYADsrh1lB3v/ft/WVFlVzOIm+Q0p7U7VqHI6qr7NWHYKe+Wif3W50n7JAFoBsWVsoU0+qDks6WQ60g=="
+      "version": "1.5.13",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
+      "integrity": "sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q=="
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -17858,27 +17800,27 @@
       }
     },
     "node_modules/ember-file-upload": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/ember-file-upload/-/ember-file-upload-7.3.0.tgz",
-      "integrity": "sha512-ze9AEMejnW2Nri51HmOoHQ8TJKLs8yAIZ1mk2C7VXpKVJbwtiy7Gda7pbSRskg9xrz4L16h0yia9fSCmuXIaUg==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/ember-file-upload/-/ember-file-upload-8.4.1.tgz",
+      "integrity": "sha512-VeKNNaL5LEo7P6TZqMFXyPSb5kJcjkUG/VNNOll0iZ/EyIXC2fZme64mNyXYheGBLiPk5H1gUsunSNpR6sg1GQ==",
       "dev": true,
       "dependencies": {
-        "@ember/test-helpers": "^2.9.3",
         "@ember/test-waiters": "^3.0.0",
         "@embroider/addon-shim": "^1.5.0",
         "@embroider/macros": "^1.0.0",
-        "@glimmer/component": "^1.0.4",
-        "@glimmer/tracking": "^1.0.4",
-        "ember-auto-import": "^2.0.0",
-        "ember-modifier": "^3.2.7 || ^4.0.0",
-        "tracked-built-ins": "^3.0.0"
+        "ember-auto-import": "^2.0.0"
       },
       "engines": {
-        "node": "14.* || 16.* || >= 18"
+        "node": "16.* || >= 18"
       },
       "peerDependencies": {
+        "@ember/test-helpers": "^2.9.3 || ^3.0.3",
+        "@glimmer/component": "^1.1.2",
+        "@glimmer/tracking": "^1.1.2",
         "ember-cli-mirage": "*",
-        "miragejs": "*"
+        "ember-modifier": "^3.2.7 || ^4.1.0",
+        "miragejs": "*",
+        "tracked-built-ins": "^3.1.1"
       },
       "peerDependenciesMeta": {
         "ember-cli-mirage": {
@@ -21609,9 +21551,9 @@
       "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw=="
     },
     "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "engines": {
         "node": ">=6"
       }
@@ -25179,9 +25121,9 @@
       }
     },
     "node_modules/inputmask": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-5.0.8.tgz",
-      "integrity": "sha512-1WcbyudPTXP1B28ozWWyFa6QRIUG4KiLoyR6LFHlpT4OfTzRqFfWgHFadNvRuMN1S9XNVz9CdNvCGjJi+uAMqQ==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-5.0.9.tgz",
+      "integrity": "sha512-s0lUfqcEbel+EQXtehXqwCJGShutgieOaIImFKC/r4reYNvX3foyrChl6LOEvaEgxEbesePIrw1Zi2jhZaDZbQ==",
       "dev": true
     },
     "node_modules/inquirer": {
@@ -28739,9 +28681,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
     },
     "node_modules/node-watch": {
       "version": "0.7.3",
@@ -29938,9 +29880,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
+      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -32116,9 +32058,9 @@
       "dev": true
     },
     "node_modules/resolve": {
-      "version": "1.22.4",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
-      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -35766,17 +35708,13 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/tracked-built-ins": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/tracked-built-ins/-/tracked-built-ins-3.1.1.tgz",
-      "integrity": "sha512-W8qLBxZzeC2zhEDdbPKi2GTffsiFn8PRbgal/2Fl6E/84CMvnpS6cPMmkvUmSLgKbqcAxl/RhyjWnhIZ9iPQjQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/tracked-built-ins/-/tracked-built-ins-3.3.0.tgz",
+      "integrity": "sha512-ewKFrW/AQs05oLPM5isOUb/1aOwBRfHfmF408CCzTk21FLAhKrKVOP5Q5ebX+zCT4kvg81PGBGwrBiEGND1nWA==",
       "dev": true,
       "dependencies": {
-        "ember-cli-babel": "^7.26.10",
-        "ember-cli-typescript": "^5.1.0",
+        "@embroider/addon-shim": "^1.8.3",
         "ember-tracked-storage-polyfill": "^1.0.0"
-      },
-      "engines": {
-        "node": "14.* || 16.* || >= 18.*"
       }
     },
     "node_modules/tracked-toolbox": {
@@ -36333,9 +36271,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -36351,8 +36289,8 @@
         }
       ],
       "dependencies": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0"
+        "escalade": "^3.1.2",
+        "picocolors": "^1.0.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "joi": "^17.13.3"
       },
       "devDependencies": {
-        "@appuniversum/ember-appuniversum": "^2.7.0",
+        "@appuniversum/ember-appuniversum": "^2.18.0",
         "@babel/eslint-parser": "^7.22.15",
         "@babel/plugin-proposal-decorators": "^7.22.10",
         "@bagaar/ember-breadcrumbs": "^4.1.0",
@@ -149,38 +149,41 @@
       }
     },
     "node_modules/@appuniversum/ember-appuniversum": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-2.7.0.tgz",
-      "integrity": "sha512-/crrTctcxeRVjJbWNOZHZrdpRy31kyTbtexwxE5R/LNrRNRqmPJ9HRBWy5X499PwqVy2UaMlLkVia3DDizuQoQ==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-2.18.0.tgz",
+      "integrity": "sha512-W67tWC3racq9Eq9ziV4heFhAPeoRG0ILPtjKmYwM0BeIQ8k+L6Fp3Vrnh741yQBERNkdAr6F8XQu4G8mNbkBow==",
       "dev": true,
       "dependencies": {
+        "@babel/core": "^7.22.10",
         "@duetds/date-picker": "^1.4.0",
         "@embroider/macros": "^1.9.0",
         "@floating-ui/dom": "^1.1.0",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
         "@zestia/ember-auto-focus": "^4.2.0",
-        "ember-auto-import": "^2.5.0",
+        "ember-auto-import": "^2.6.3",
         "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.2.0",
+        "ember-cli-htmlbars": "^6.3.0",
+        "ember-concurrency": "2.x || ^3.1.0",
         "ember-data-table": "^2.1.0",
         "ember-file-upload": "^7.0.3",
-        "ember-focus-trap": "^1.0.2",
+        "ember-focus-trap": "^1.1.0",
         "ember-modifier": "^3.2.7",
+        "ember-template-imports": "^3.4.2",
         "ember-test-selectors": "^6.0.0",
+        "ember-truth-helpers": "^3.1.1",
         "inputmask": "^5.0.7",
         "merge-anything": "^5.1.3",
-        "tracked-toolbox": "^1.2.3"
+        "tracked-toolbox": "^2.0.0"
       },
       "engines": {
         "node": "14.* || 16.* || >= 18"
       },
       "optionalDependencies": {
-        "ember-concurrency": "2.x",
-        "ember-power-select": "2.x || 3.x || 4.x || 5.x || 6.x"
+        "ember-power-select": "2.x || 3.x || 4.x || 5.x || 6.x || 7.x"
       },
       "peerDependencies": {
-        "ember-source": "^3.28.0 || ^4.0.0"
+        "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/@appuniversum/ember-appuniversum/node_modules/async-disk-cache": {
@@ -188,7 +191,6 @@
       "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
       "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "debug": "^4.1.1",
         "heimdalljs": "^0.2.3",
@@ -207,7 +209,6 @@
       "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
       "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "async-disk-cache": "^2.0.0",
         "async-promise-queue": "^1.0.3",
@@ -230,7 +231,6 @@
       "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
       "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "broccoli-node-api": "^1.7.0",
         "broccoli-output-wrapper": "^3.2.5",
@@ -249,7 +249,6 @@
       "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
       "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
       "dev": true,
-      "optional": true,
       "engines": {
         "node": "10.* || >= 12.*"
       }
@@ -259,7 +258,6 @@
       "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
       "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "errlop": "^2.0.0",
         "semver": "^6.3.0"
@@ -276,57 +274,8 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@appuniversum/ember-appuniversum/node_modules/ember-basic-dropdown": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/ember-basic-dropdown/-/ember-basic-dropdown-6.0.2.tgz",
-      "integrity": "sha512-JgI/cy7eS/Y2WoQl7B2Mko/1aFTAlxr5d+KpQeH7rBKOFml7IQtLvhiDQrpU/FLkrQ9aLNEJtzwtDZV1xQxAKA==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@ember/render-modifiers": "^2.0.4",
-        "@embroider/macros": "^1.2.0",
-        "@embroider/util": "^1.2.0",
-        "@glimmer/component": "^1.0.4",
-        "@glimmer/tracking": "^1.0.4",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.0.1",
-        "ember-cli-typescript": "^4.2.1",
-        "ember-element-helper": "^0.6.0",
-        "ember-get-config": "^2.1.1",
-        "ember-maybe-in-element": "^2.0.3",
-        "ember-modifier": "^3.2.7",
-        "ember-style-modifier": "^0.8.0 || ^1.0.0",
-        "ember-truth-helpers": "^2.1.0 || ^3.0.0"
-      },
-      "engines": {
-        "node": "12.* || 14.* || >= 16"
-      }
-    },
-    "node_modules/@appuniversum/ember-appuniversum/node_modules/ember-cli-typescript": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
-      "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "ansi-to-html": "^0.6.15",
-        "broccoli-stew": "^3.0.0",
-        "debug": "^4.0.0",
-        "execa": "^4.0.0",
-        "fs-extra": "^9.0.1",
-        "resolve": "^1.5.0",
-        "rsvp": "^4.8.1",
-        "semver": "^7.3.2",
-        "stagehand": "^1.0.0",
-        "walk-sync": "^2.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
       }
     },
     "node_modules/@appuniversum/ember-appuniversum/node_modules/ember-concurrency": {
@@ -334,7 +283,6 @@
       "resolved": "https://registry.npmjs.org/ember-concurrency/-/ember-concurrency-2.3.7.tgz",
       "integrity": "sha512-sz6sTIXN/CuLb5wdpauFa+rWXuvXXSnSHS4kuNzU5GSMDX1pLBWSuovoUk61FUe6CYRqBmT1/UushObwBGickQ==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13",
         "@babel/types": "^7.12.13",
@@ -354,7 +302,6 @@
       "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
       "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "@ember/edition-utils": "^1.2.0",
         "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
@@ -377,74 +324,11 @@
         "node": "10.* || >= 12.*"
       }
     },
-    "node_modules/@appuniversum/ember-appuniversum/node_modules/ember-power-select": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ember-power-select/-/ember-power-select-6.0.1.tgz",
-      "integrity": "sha512-YslsjEUzdHhFfUP7IlklQuKt6rFG/VS38JLCjTYiCcBKrl76pxky/PoGMx3V+Ukh5mI77mGfA7BSKpKv8MAQAw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@embroider/util": "^1.0.0",
-        "@glimmer/component": "^1.1.2",
-        "@glimmer/tracking": "^1.1.2",
-        "ember-assign-helper": "^0.4.0",
-        "ember-basic-dropdown": "^6.0.0",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.1.0",
-        "ember-cli-typescript": "^4.2.0",
-        "ember-concurrency": ">=1.0.0 <3",
-        "ember-concurrency-decorators": "^2.0.0",
-        "ember-text-measurer": "^0.6.0",
-        "ember-truth-helpers": "^3.0.0"
-      },
-      "engines": {
-        "node": "14.* || >= 16"
-      }
-    },
-    "node_modules/@appuniversum/ember-appuniversum/node_modules/ember-style-modifier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ember-style-modifier/-/ember-style-modifier-1.0.0.tgz",
-      "integrity": "sha512-ANkYpOeI3/tkRxVz750ymb8cQBqfBTKOUOz4RPRsNys8rlaBiaKEa95XLz1JWfCXCzjmqe8i2cIdnAMix+nb3A==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "ember-cli-babel": "^7.26.11",
-        "ember-modifier": "^3.2.7"
-      },
-      "engines": {
-        "node": "14.* || >= 16"
-      }
-    },
-    "node_modules/@appuniversum/ember-appuniversum/node_modules/execa": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
     "node_modules/@appuniversum/ember-appuniversum/node_modules/fs-tree-diff": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
       "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "@types/symlink-or-copy": "^1.2.0",
         "heimdalljs-logger": "^0.1.7",
@@ -456,38 +340,11 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/@appuniversum/ember-appuniversum/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@appuniversum/ember-appuniversum/node_modules/human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=8.12.0"
-      }
-    },
     "node_modules/@appuniversum/ember-appuniversum/node_modules/istextorbinary": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
       "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "binaryextensions": "^2.1.2",
         "editions": "^2.2.0",
@@ -505,7 +362,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
-      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -515,7 +371,6 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -528,7 +383,6 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -544,7 +398,6 @@
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true,
-      "optional": true,
       "engines": {
         "node": "6.* || >= 7.*"
       }
@@ -554,7 +407,6 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
       "dev": true,
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -564,7 +416,6 @@
       "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
       "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "@types/minimatch": "^3.0.3",
         "ensure-posix-path": "^1.1.0",
@@ -3939,19 +3790,6 @@
       },
       "engines": {
         "node": "16.* || >= 18"
-      }
-    },
-    "node_modules/@ember-decorators/utils": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@ember-decorators/utils/-/utils-6.1.1.tgz",
-      "integrity": "sha512-0KqnoeoLKb6AyoSU65TRF5T85wmS4uDn06oARddwNPxxf/lt5jQlh41uX3W7V/fWL9tPu8x1L1Vvpc80MN1+YA==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "ember-cli-babel": "^7.1.3"
-      },
-      "engines": {
-        "node": ">= 8.*"
       }
     },
     "node_modules/@ember/edition-utils": {
@@ -14855,9 +14693,9 @@
       "dev": true
     },
     "node_modules/ember-cli-htmlbars": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-6.2.0.tgz",
-      "integrity": "sha512-j5EGixjGau23HrqRiW/JjoAovg5UBHfjbyN7wX5ekE90knIEqUUj1z/Mo/cTx/J2VepQ2lE6HdXW9LWQ/WdMtw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-6.3.0.tgz",
+      "integrity": "sha512-N9Y80oZfcfWLsqickMfRd9YByVcTGyhYRnYQ2XVPVrp6jyUyOeRWmEAPh7ERSXpp8Ws4hr/JB9QVQrn/yZa+Ag==",
       "dev": true,
       "dependencies": {
         "@ember/edition-utils": "^1.2.0",
@@ -16035,386 +15873,6 @@
       },
       "peerDependencies": {
         "ember-source": "^3.28.0 || ^4.0.0 || >=5.0.0"
-      }
-    },
-    "node_modules/ember-concurrency-decorators": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/ember-concurrency-decorators/-/ember-concurrency-decorators-2.0.3.tgz",
-      "integrity": "sha512-r6O34YKI/slyYapVsuOPnmaKC4AsmBSwvgcadbdy+jHNj+mnryXPkm+3hhhRnFdlsKUKdEuXvl43lhjhYRLhhA==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@ember-decorators/utils": "^6.1.0",
-        "ember-cli-babel": "^7.19.0",
-        "ember-cli-htmlbars": "^4.3.1",
-        "ember-cli-typescript": "^3.1.4"
-      },
-      "engines": {
-        "node": "10.* || >= 12"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.8.7.tgz",
-      "integrity": "sha512-7O0UsPQVNKqpHeHLpfvOG4uXmlw+MOxYvUv6Otc9uH5SYMIxvF6eBdjkWvC3f9G+VXe0RsNExyAQBeTRug/wqQ==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/plugin-syntax-typescript": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/babel-plugin-htmlbars-inline-precompile": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-3.2.0.tgz",
-      "integrity": "sha512-IUeZmgs9tMUGXYu1vfke5I18yYJFldFGdNFQOWslXTnDWXzpwPih7QFduUqvT+awDpDuNtXpdt5JAf43Q1Hhzg==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": "8.* || 10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/broccoli-output-wrapper": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/broccoli-output-wrapper/-/broccoli-output-wrapper-2.0.0.tgz",
-      "integrity": "sha512-V/ozejo+snzNf75i/a6iTmp71k+rlvqjE3+jYfimuMwR1tjNNRdtfno+NGNQB2An9bIAeqZnKhMDurAznHAdtA==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "heimdalljs-logger": "^0.1.10"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/broccoli-persistent-filter": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-2.3.1.tgz",
-      "integrity": "sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "async-disk-cache": "^1.2.1",
-        "async-promise-queue": "^1.0.3",
-        "broccoli-plugin": "^1.0.0",
-        "fs-tree-diff": "^2.0.0",
-        "hash-for-dep": "^1.5.0",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "mkdirp": "^0.5.1",
-        "promise-map-series": "^0.2.1",
-        "rimraf": "^2.6.1",
-        "rsvp": "^4.7.0",
-        "symlink-or-copy": "^1.0.1",
-        "sync-disk-cache": "^1.3.3",
-        "walk-sync": "^1.0.0"
-      },
-      "engines": {
-        "node": "6.* || >= 8.*"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/broccoli-persistent-filter/node_modules/matcher-collection": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
-      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "minimatch": "^3.0.2"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/broccoli-persistent-filter/node_modules/walk-sync": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
-      "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^1.1.1"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/ember-cli-htmlbars": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-4.5.0.tgz",
-      "integrity": "sha512-bYJpK1pqFu9AadDAGTw05g2LMNzY8xTCIqQm7dMJmKEoUpLRFbPf4SfHXrktzDh7Q5iggl6Skzf1M0bPlIxARw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-htmlbars-inline-precompile": "^3.2.0",
-        "broccoli-debug": "^0.6.5",
-        "broccoli-persistent-filter": "^2.3.1",
-        "broccoli-plugin": "^3.1.0",
-        "common-tags": "^1.8.0",
-        "ember-cli-babel-plugin-helpers": "^1.1.0",
-        "fs-tree-diff": "^2.0.1",
-        "hash-for-dep": "^1.5.1",
-        "heimdalljs-logger": "^0.1.10",
-        "json-stable-stringify": "^1.0.1",
-        "semver": "^6.3.0",
-        "strip-bom": "^4.0.0",
-        "walk-sync": "^2.0.2"
-      },
-      "engines": {
-        "node": "8.* || 10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/ember-cli-htmlbars/node_modules/broccoli-plugin": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-3.1.0.tgz",
-      "integrity": "sha512-7w7FP8WJYjLvb0eaw27LO678TGGaom++49O1VYIuzjhXjK5kn2+AMlDm7CaUFw4F7CLGoVQeZ84d8gICMJa4lA==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "broccoli-node-api": "^1.6.0",
-        "broccoli-output-wrapper": "^2.0.0",
-        "fs-merger": "^3.0.1",
-        "promise-map-series": "^0.2.1",
-        "quick-temp": "^0.1.3",
-        "rimraf": "^2.3.4",
-        "symlink-or-copy": "^1.1.8"
-      },
-      "engines": {
-        "node": "8.* || 10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/ember-cli-typescript": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-3.1.4.tgz",
-      "integrity": "sha512-HJ73kL45OGRmIkPhBNFt31I1SGUvdZND+LCH21+qpq3pPlFpJG8GORyXpP+2ze8PbnITNLzwe5AwUrpyuRswdQ==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",
-        "@babel/plugin-proposal-optional-chaining": "^7.6.0",
-        "@babel/plugin-transform-typescript": "~7.8.0",
-        "ansi-to-html": "^0.6.6",
-        "broccoli-stew": "^3.0.0",
-        "debug": "^4.0.0",
-        "ember-cli-babel-plugin-helpers": "^1.0.0",
-        "execa": "^3.0.0",
-        "fs-extra": "^8.0.0",
-        "resolve": "^1.5.0",
-        "rsvp": "^4.8.1",
-        "semver": "^6.3.0",
-        "stagehand": "^1.0.0",
-        "walk-sync": "^2.0.0"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/execa": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
-      "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "p-finally": "^2.0.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": "^8.12.0 || >=9.7.0"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/fs-tree-diff": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-      "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@types/symlink-or-copy": "^1.2.0",
-        "heimdalljs-logger": "^0.1.7",
-        "object-assign": "^4.1.0",
-        "path-posix": "^1.0.0",
-        "symlink-or-copy": "^1.1.8"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=8.12.0"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "optional": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "optional": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/p-finally": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/strip-bom": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/sync-disk-cache": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-1.3.4.tgz",
-      "integrity": "sha512-GlkGeM81GPPEKz/lH7QUTbvqLq7K/IUTuaKDSMulP9XQ42glqNJIN/RKgSOw4y8vxL1gOVvj+W7ruEO4s36eCw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "debug": "^2.1.3",
-        "heimdalljs": "^0.2.3",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^2.2.8",
-        "username-sync": "^1.0.2"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/sync-disk-cache/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/ember-concurrency-decorators/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
       }
     },
     "node_modules/ember-config-helper": {
@@ -18432,9 +17890,9 @@
       }
     },
     "node_modules/ember-focus-trap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ember-focus-trap/-/ember-focus-trap-1.0.2.tgz",
-      "integrity": "sha512-/8Cx9KI7uqoMaNN4Iyxc24P2JIvAcCL3cI1tYdZRHTwTd1sG6esEZWOnpxZOSE7m4xHww8HVUSiXzgyqD8YIhA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ember-focus-trap/-/ember-focus-trap-1.1.0.tgz",
+      "integrity": "sha512-KxbCKpAJaBVZm+bW4tHPoBJAZThmxa6pI+WQusL+bj0RtAnGUNkWsVy6UBMZ5QqTQzf4EvGHkCVACVp5lbAWMQ==",
       "dev": true,
       "dependencies": {
         "@embroider/addon-shim": "^1.0.0",
@@ -18442,6 +17900,9 @@
       },
       "engines": {
         "node": "12.* || >= 14"
+      },
+      "peerDependencies": {
+        "ember-source": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/ember-get-config": {
@@ -36319,16 +35780,24 @@
       }
     },
     "node_modules/tracked-toolbox": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tracked-toolbox/-/tracked-toolbox-1.3.0.tgz",
-      "integrity": "sha512-KHfYLvNyRr0qQeXQPnmb6Z4JYZ0/47R7LjVwzUrsKc539eQi3Sz2z3mb7FJN9KgaJXVuM3GQ8zcwUFTf0hrOsQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tracked-toolbox/-/tracked-toolbox-2.0.0.tgz",
+      "integrity": "sha512-adZtX+RGN6F+pWs/5JqVuDxLhuia4uhqmQp+UlUaxpykWjDFETtAdQR+LdDJiFPXFAXnS6FBqn/tnSLJQCm3Yw==",
       "dev": true,
       "dependencies": {
-        "ember-cache-primitive-polyfill": "^1.0.0",
-        "ember-cli-babel": "^7.26.6"
+        "@embroider/addon-shim": "^1.6.0",
+        "ember-cache-primitive-polyfill": "^1.0.0"
       },
       "engines": {
-        "node": "8.* || >= 10.*"
+        "node": "14.* || 16.* || >= 18"
+      },
+      "peerDependencies": {
+        "ember-source": "*"
+      },
+      "peerDependenciesMeta": {
+        "ember-source": {
+          "optional": true
+        }
       }
     },
     "node_modules/tree-kill": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "release": "release-it"
   },
   "devDependencies": {
-    "@appuniversum/ember-appuniversum": "^2.7.0",
+    "@appuniversum/ember-appuniversum": "^2.18.0",
     "@babel/eslint-parser": "^7.22.15",
     "@babel/plugin-proposal-decorators": "^7.22.10",
     "@bagaar/ember-breadcrumbs": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "release": "release-it"
   },
   "devDependencies": {
-    "@appuniversum/ember-appuniversum": "^2.18.0",
+    "@appuniversum/ember-appuniversum": "^3.5.0",
     "@babel/eslint-parser": "^7.22.15",
     "@babel/plugin-proposal-decorators": "^7.22.10",
     "@bagaar/ember-breadcrumbs": "^4.1.0",
@@ -39,7 +39,7 @@
     "@ember/test-helpers": "^2.9.4",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
-    "@lblod/ember-environment-banner": "^0.2.0",
+    "@lblod/ember-environment-banner": "^0.5.0",
     "@lblod/ember-mock-login": "^0.7.0",
     "@release-it-plugins/lerna-changelog": "^7.0.0",
     "@tsconfig/ember": "^2.0.0",


### PR DESCRIPTION
This updates the app to Appuniversum v3 using the [migration guide](https://github.com/appuniversum/ember-appuniversum/pull/459) and also resolves any v3 deprecations that are present in the app.
