### PR TITLE
Fix the `RouterService` types

### DIFF
--- a/app/components/codelist-form.ts
+++ b/app/components/codelist-form.ts
@@ -11,7 +11,7 @@ import CodeListModel from 'mow-registry/models/code-list';
 import SkosConcept from 'mow-registry/models/skos-concept';
 import ArrayProxy from '@ember/array/proxy';
 import Store from '@ember-data/store';
-import Router from '@ember/routing/router';
+import type RouterService from '@ember/routing/router-service';
 import IconModel from 'mow-registry/models/icon';
 
 type Args = {
@@ -19,7 +19,7 @@ type Args = {
 };
 
 export default class CodelistFormComponent extends Component<Args> {
-  @service declare router: Router;
+  @service declare router: RouterService;
   @service declare store: Store;
 
   @tracked newValue = '';

--- a/app/components/icon-catalog-form.ts
+++ b/app/components/icon-catalog-form.ts
@@ -1,4 +1,4 @@
-import Router from '@ember/routing/router';
+import type RouterService from '@ember/routing/router-service';
 import ImageUploadHandlerComponent from './image-upload-handler';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
@@ -9,7 +9,7 @@ type Args = {
   icon: IconModel;
 };
 export default class IconCatalogFormComponent extends ImageUploadHandlerComponent<Args> {
-  @service declare router: Router;
+  @service declare router: RouterService;
 
   get isSaving() {
     return this.editIconTask.isRunning;

--- a/app/components/road-marking-form.ts
+++ b/app/components/road-marking-form.ts
@@ -2,7 +2,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { dropTask } from 'ember-concurrency';
 import ImageUploadHandlerComponent from './image-upload-handler';
-import Router from '@ember/routing/router';
+import type RouterService from '@ember/routing/router-service';
 import RoadMarkingConceptModel from 'mow-registry/models/road-marking-concept';
 import Store from '@ember-data/store';
 import TrafficSignConceptModel from 'mow-registry/models/traffic-sign-concept';
@@ -12,7 +12,7 @@ type Args = {
 };
 
 export default class RoadMarkingFormComponent extends ImageUploadHandlerComponent<Args> {
-  @service declare router: Router;
+  @service declare router: RouterService;
   @service declare store: Store;
 
   get isSaving() {

--- a/app/components/road-sign-form.ts
+++ b/app/components/road-sign-form.ts
@@ -1,4 +1,4 @@
-import Router from '@ember/routing/router';
+import type RouterService from '@ember/routing/router-service';
 import ImageUploadHandlerComponent from './image-upload-handler';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
@@ -13,7 +13,7 @@ type Args = {
   roadSignConcept: RoadSignConceptModel;
 };
 export default class RoadSignFormComponent extends ImageUploadHandlerComponent<Args> {
-  @service declare router: Router;
+  @service declare router: RouterService;
 
   @tracked shapesToRemove: TribontShapeModel[] = [];
   get isSaving() {

--- a/app/components/traffic-light-form.ts
+++ b/app/components/traffic-light-form.ts
@@ -2,7 +2,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { dropTask } from 'ember-concurrency';
 import ImageUploadHandlerComponent from './image-upload-handler';
-import Router from '@ember/routing/router';
+import type RouterService from '@ember/routing/router-service';
 import TrafficLightConceptModel from 'mow-registry/models/traffic-light-concept';
 import Store from '@ember-data/store';
 import TrafficSignConceptModel from 'mow-registry/models/traffic-sign-concept';
@@ -12,7 +12,7 @@ type Args = {
 };
 
 export default class TrafficLightFormComponent extends ImageUploadHandlerComponent<Args> {
-  @service declare router: Router;
+  @service declare router: RouterService;
   @service declare store: Store;
 
   get isSaving() {

--- a/app/components/traffic-measure/index.ts
+++ b/app/components/traffic-measure/index.ts
@@ -5,7 +5,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { htmlSafe } from '@ember/template';
 import Store from '@ember-data/store';
-import Router from '@ember/routing/router';
+import type RouterService from '@ember/routing/router-service';
 import IntlService from 'ember-intl/services/intl';
 import CodelistsService from 'mow-registry/services/codelists';
 import TrafficMeasureConceptModel from 'mow-registry/models/traffic-measure-concept';
@@ -32,7 +32,7 @@ type Args = {
 
 export default class TrafficMeasureIndexComponent extends Component<Args> {
   @service declare store: Store;
-  @service declare router: Router;
+  @service declare router: RouterService;
   @service declare intl: IntlService;
   @service('codelists') declare codeListService: CodelistsService;
 

--- a/app/controllers/codelists-management/codelist.ts
+++ b/app/controllers/codelists-management/codelist.ts
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import Router from '@ember/routing/router';
+import type RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import IconModel from 'mow-registry/models/icon';
@@ -9,7 +9,7 @@ import { ModelFrom } from 'mow-registry/utils/type-utils';
 
 export default class CodelistController extends Controller {
   declare model: ModelFrom<CodelistsManagementCodelistRoute>;
-  @service declare router: Router;
+  @service declare router: RouterService;
   @tracked isOpen = false;
 
   @action

--- a/app/controllers/icon-catalog/icon.ts
+++ b/app/controllers/icon-catalog/icon.ts
@@ -2,13 +2,13 @@ import Controller from '@ember/controller';
 import { task } from 'ember-concurrency';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import Router from '@ember/routing/router';
+import type RouterService from '@ember/routing/router-service';
 import { ModelFrom } from 'mow-registry/utils/type-utils';
 import IconCatalogIconRoute from 'mow-registry/routes/icon-catalog/icon';
 import IconModel from 'mow-registry/models/icon';
 
 export default class IconCatalogIconController extends Controller {
-  @service declare router: Router;
+  @service declare router: RouterService;
   declare model: ModelFrom<IconCatalogIconRoute>;
 
   @tracked isOpen = false;

--- a/app/controllers/road-marking-concepts/road-marking-concept.ts
+++ b/app/controllers/road-marking-concepts/road-marking-concept.ts
@@ -1,7 +1,7 @@
 import ArrayProxy from '@ember/array/proxy';
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import Router from '@ember/routing/router';
+import type RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
@@ -15,7 +15,7 @@ import { unwrap } from 'mow-registry/utils/option';
 import { ModelFrom } from 'mow-registry/utils/type-utils';
 
 export default class RoadmarkingConceptsRoadmarkingConceptController extends Controller {
-  @service declare router: Router;
+  @service declare router: RouterService;
   declare model: ModelFrom<RoadmarkingConcept>;
 
   @tracked isAddingRelatedRoadSigns = false;
@@ -42,14 +42,10 @@ export default class RoadmarkingConceptsRoadmarkingConceptController extends Con
   }
 
   get hasActiveChildRoute(): boolean {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return (
-      //@ts-expect-error for some reason, the currentRouteName property is not included in the types
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
       this.router.currentRouteName.startsWith(
         'road-marking-concepts.road-marking-concept',
       ) &&
-      //@ts-expect-error for some reason, the currentRouteName property is not included in the types
       this.router.currentRouteName !==
         'road-marking-concepts.road-marking-concept.index'
     );
@@ -57,7 +53,6 @@ export default class RoadmarkingConceptsRoadmarkingConceptController extends Con
 
   get isAddingInstructions() {
     return (
-      //@ts-expect-error for some reason, the currentRouteName property is not included in the types
       this.router.currentRouteName ===
       'road-marking-concepts.road-marking-concept.instruction'
     );

--- a/app/controllers/road-sign-concepts/road-sign-concept.ts
+++ b/app/controllers/road-sign-concepts/road-sign-concept.ts
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import Router from '@ember/routing/router';
+import type RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
@@ -13,7 +13,7 @@ import RoadsignConcept from 'mow-registry/routes/road-sign-concepts/road-sign-co
 import { ModelFrom } from 'mow-registry/utils/type-utils';
 
 export default class RoadsignConceptsRoadsignConceptController extends Controller {
-  @service declare router: Router;
+  @service declare router: RouterService;
   declare model: ModelFrom<RoadsignConcept>;
 
   @tracked isAddingSubSigns = false;
@@ -291,7 +291,6 @@ export default class RoadsignConceptsRoadsignConceptController extends Controlle
 
   get isAddingInstructions() {
     return (
-      //@ts-expect-error for some reason, the currentRouteName property is not included in the types
       this.router.currentRouteName ===
       'road-sign-concepts.road-sign-concept.instruction'
     );
@@ -332,14 +331,10 @@ export default class RoadsignConceptsRoadsignConceptController extends Controlle
   }
 
   get hasActiveChildRoute(): boolean {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return (
-      //@ts-expect-error for some reason, the currentRouteName property is not included in the types
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
       this.router.currentRouteName.startsWith(
         'road-sign-concepts.road-sign-concept',
       ) &&
-      //@ts-expect-error for some reason, the currentRouteName property is not included in the types
       this.router.currentRouteName !==
         'road-sign-concepts.road-sign-concept.index'
     );

--- a/app/controllers/traffic-light-concepts/traffic-light-concept.ts
+++ b/app/controllers/traffic-light-concepts/traffic-light-concept.ts
@@ -3,7 +3,7 @@ import { task } from 'ember-concurrency';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import Router from '@ember/routing/router';
+import type RouterService from '@ember/routing/router-service';
 import { ModelFrom } from 'mow-registry/utils/type-utils';
 import TrafficlightConcept from 'mow-registry/routes/traffic-light-concepts/traffic-light-concept';
 import RoadSignConceptModel from 'mow-registry/models/road-sign-concept';
@@ -13,7 +13,7 @@ import RoadSignCategoryModel from 'mow-registry/models/road-sign-category';
 import ArrayProxy from '@ember/array/proxy';
 
 export default class TrafficLightConceptsTrafficLightConceptController extends Controller {
-  @service declare router: Router;
+  @service declare router: RouterService;
   declare model: ModelFrom<TrafficlightConcept>;
 
   @tracked isAddingRelatedRoadSigns = false;
@@ -223,13 +223,10 @@ export default class TrafficLightConceptsTrafficLightConceptController extends C
   }
 
   get hasActiveChildRoute(): boolean {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return (
-      //@ts-expect-error for some reason, the currentRouteName property is not included in the types
-      (this.router.currentRouteName as string).startsWith(
+      this.router.currentRouteName.startsWith(
         'traffic-light-concepts.traffic-light-concept',
       ) &&
-      //@ts-expect-error for some reason, the currentRouteName property is not included in the types
       this.router.currentRouteName !==
         'traffic-light-concepts.traffic-light-concept.index'
     );
@@ -237,7 +234,6 @@ export default class TrafficLightConceptsTrafficLightConceptController extends C
 
   get isAddingInstructions() {
     return (
-      //@ts-expect-error for some reason, the currentRouteName property is not included in the types
       this.router.currentRouteName ===
       'traffic-light-concepts.traffic-light-concept.instruction'
     );


### PR DESCRIPTION
We were accidentally using the `Router` types instead of the `RouterService` which are both different things. This required us to use ts-ignore comments in some places. This uses the proper types so we can remove the ignore comments and prevent similar issues in the future.