### PR TITLE
Fix a road-sign-concept validation issue

### DIFF
--- a/app/models/road-sign-concept.ts
+++ b/app/models/road-sign-concept.ts
@@ -7,6 +7,7 @@ import {
 import type RoadMarkingConcept from 'mow-registry/models/road-marking-concept';
 import type TrafficLightConcept from 'mow-registry/models/traffic-light-concept';
 import {
+  validateBelongsToOptional,
   validateHasManyOptional,
   validateHasManyRequired,
 } from 'mow-registry/validators/schema';
@@ -77,7 +78,7 @@ export default class RoadSignConcept extends TrafficSignConcept {
       relatedFromRoadSignConcepts: validateHasManyOptional(),
       relatedRoadMarkingConcepts: validateHasManyOptional(),
       relatedTrafficLightConcepts: validateHasManyOptional(),
-      zonality: validateHasManyOptional(),
+      zonality: validateBelongsToOptional(),
     });
   }
 }


### PR DESCRIPTION
While working on the redesign I noticed creating road signs was broken. It seems I accidentally created a regression in the TS work.

"Zonality" is a belongsTo relationship, so the validationSchema was wrong which means the validations always failed as well.