### PR TITLE
Validated boolean migration (fix)

### DIFF
--- a/app/models/traffic-measure-concept.ts
+++ b/app/models/traffic-measure-concept.ts
@@ -14,6 +14,7 @@ export default class TrafficMeasureConcept extends Model {
   declare [Type]: 'traffic-measure-concept';
   @attr declare label?: string;
   @attr declare variableSignage?: string;
+  @attr declare valid?: boolean;
 
   @belongsTo<SkosConcept>('skos-concept', { inverse: null, async: true })
   declare zonality: AsyncBelongsTo<SkosConcept>;


### PR DESCRIPTION
## Overview
Added a `valid` property on the traffic measure model. Before the traffic measure model inherited the property from the old `Concept` model. On the new model we're not using that superclass anymore.
We already added them on the `TrafficSignConcept` superclass, but that doesn't include measures, so here is that fix.

##### connected issues and PRs:
a fix of https://github.com/lblod/frontend-mow-registry/pull/285