### PR TITLE
[GN-4967] Fix the logout url setup

### DIFF
--- a/app/services/session.js
+++ b/app/services/session.js
@@ -2,8 +2,13 @@ import BaseSessionService from 'ember-simple-auth/services/session';
 import ENV from 'mow-registry/config/environment';
 
 export default class SessionService extends BaseSessionService {
-  handleInvalidation() {
+  handleInvalidation(routeAfterInvalidation) {
     const logoutUrl = ENV['torii']['providers']['acmidm-oauth2']['logoutUrl'];
-    super.handleInvalidation(logoutUrl);
+
+    if (!logoutUrl.startsWith('{{')) {
+      super.handleInvalidation(logoutUrl);
+    } else {
+      super.handleInvalidation(routeAfterInvalidation);
+    }
   }
 }


### PR DESCRIPTION
We now only use the logoutUrl value if it is actually configured. Environments that don't use ACM/IDM don't need a custom logout url.