### PR TITLE
Draggable object bugfix

### DIFF
--- a/app/components/traffic-measure/index.ts
+++ b/app/components/traffic-measure/index.ts
@@ -137,10 +137,10 @@ export default class TrafficMeasureIndexComponent extends Component<Args> {
           return 0;
         }
       });
-      // const relations = await this.trafficMeasureConcept.getOrderedRelations(); 
+      // const relations = await this.trafficMeasureConcept.getOrderedRelations();
     }
 
-    this.signs = A(relatedTrafficSigns.slice())
+    this.signs = A([...relatedTrafficSigns]);
 
     await this.fetchInstructions.perform();
 
@@ -196,14 +196,14 @@ export default class TrafficMeasureIndexComponent extends Component<Args> {
 
   @action
   async addSign(sign: TrafficSignConcept) {
-    this.signs.push(sign);
+    this.signs = [...this.signs, sign];
     await this.fetchInstructions.perform();
     this.selectedType = null;
   }
 
   @action
   async removeSign(sign: TrafficSignConcept) {
-    removeItem(this.signs, sign);
+    this.signs = this.signs.filter((existingSign) => existingSign !== sign);
     await this.fetchInstructions.perform();
   }
 

--- a/app/components/traffic-measure/index.ts
+++ b/app/components/traffic-measure/index.ts
@@ -21,6 +21,7 @@ import TrafficSignConcept from 'mow-registry/models/traffic-sign-concept';
 import Variable from 'mow-registry/models/variable';
 import { removeItem } from 'mow-registry/utils/array';
 import { TrackedArray } from 'tracked-built-ins';
+import { A } from '@ember/array';
 
 export type InputType = {
   value: string;
@@ -136,10 +137,10 @@ export default class TrafficMeasureIndexComponent extends Component<Args> {
           return 0;
         }
       });
-      // const relations = await this.trafficMeasureConcept.getOrderedRelations();
+      // const relations = await this.trafficMeasureConcept.getOrderedRelations(); 
     }
 
-    this.signs = new TrackedArray(relatedTrafficSigns);
+    this.signs = A(relatedTrafficSigns.slice())
 
     await this.fetchInstructions.perform();
 

--- a/app/components/traffic-measure/index.ts
+++ b/app/components/traffic-measure/index.ts
@@ -21,7 +21,7 @@ import TrafficSignConcept from 'mow-registry/models/traffic-sign-concept';
 import Variable from 'mow-registry/models/variable';
 import { removeItem } from 'mow-registry/utils/array';
 import { TrackedArray } from 'tracked-built-ins';
-import { A } from '@ember/array';
+import { A, NativeArray } from '@ember/array';
 
 export type InputType = {
   value: string;
@@ -40,7 +40,7 @@ export default class TrafficMeasureIndexComponent extends Component<Args> {
 
   @tracked codeLists?: CodeList[];
   @tracked declare trafficMeasureConcept: TrafficMeasureConcept;
-  @tracked signs: TrafficSignConcept[] = [];
+  @tracked signs: NativeArray<TrafficSignConcept> = A([]);
   @tracked variables: Variable[] = [];
   @tracked template?: Template | null;
   @tracked searchString?: string;
@@ -196,14 +196,14 @@ export default class TrafficMeasureIndexComponent extends Component<Args> {
 
   @action
   async addSign(sign: TrafficSignConcept) {
-    this.signs = [...this.signs, sign];
+    this.signs.pushObject(sign);
     await this.fetchInstructions.perform();
     this.selectedType = null;
   }
 
   @action
   async removeSign(sign: TrafficSignConcept) {
-    this.signs = this.signs.filter((existingSign) => existingSign !== sign);
+    this.signs.removeObject(sign);
     await this.fetchInstructions.perform();
   }
 
@@ -411,20 +411,25 @@ export default class TrafficMeasureIndexComponent extends Component<Args> {
     const existingRelatedSigns = (
       await trafficMeasureConcept.relatedTrafficSignConcepts
     ).slice();
+    console.log('existingRelatedSigns', existingRelatedSigns);
 
     const deletedSigns = existingRelatedSigns.filter(
       (sign) => !this.signs.includes(sign),
     );
+    console.log('deletedSigns', deletedSigns);
     const addedSigns = this.signs.filter(
       (sign) => !existingRelatedSigns.includes(sign),
     );
+    console.log('addedSigns', addedSigns);
 
     for (const sign of deletedSigns) {
+      console.log('sign that was deleted', sign);
       removeItem(await sign.hasTrafficMeasureConcepts, trafficMeasureConcept);
       await sign.save();
     }
 
     for (const sign of addedSigns) {
+      console.log('sign that was added', sign);
       (await sign.hasTrafficMeasureConcepts).push(trafficMeasureConcept);
       await sign.save();
     }

--- a/app/components/traffic-measure/index.ts
+++ b/app/components/traffic-measure/index.ts
@@ -407,32 +407,23 @@ export default class TrafficMeasureIndexComponent extends Component<Args> {
   });
 
   saveRoadsigns = task(async (trafficMeasureConcept: TrafficMeasureConcept) => {
-    // delete existing ones
     const existingRelatedSigns = (
       await trafficMeasureConcept.relatedTrafficSignConcepts
     ).slice();
-    console.log('existingRelatedSigns', existingRelatedSigns);
 
-    const deletedSigns = existingRelatedSigns.filter(
-      (sign) => !this.signs.includes(sign),
-    );
-    console.log('deletedSigns', deletedSigns);
-    const addedSigns = this.signs.filter(
-      (sign) => !existingRelatedSigns.includes(sign),
-    );
-    console.log('addedSigns', addedSigns);
-
-    for (const sign of deletedSigns) {
-      console.log('sign that was deleted', sign);
+    const removePromises = existingRelatedSigns.map(async (sign) => {
       removeItem(await sign.hasTrafficMeasureConcepts, trafficMeasureConcept);
-      await sign.save();
-    }
+      return sign.save();
+    });
+    await Promise.all(removePromises);
 
-    for (const sign of addedSigns) {
-      console.log('sign that was added', sign);
+    const addPromises = this.signs.map(async (sign) => {
       (await sign.hasTrafficMeasureConcepts).push(trafficMeasureConcept);
-      await sign.save();
-    }
+      return sign.save();
+    });
+    await Promise.all(addPromises);
+
+    await trafficMeasureConcept.save();
   });
 
   saveVariables = task(async (template: Template) => {


### PR DESCRIPTION
## Overview
While implementing the redesign of the traffic measure module, @Windvis noticed the drag and drop doesn’t work as expected.

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-5083

This PR fixes an error where the MutableArray`.replace()` was being called on an incompatible array being passed to `DraggableObject`. While investigating, I found that `this.signs` in the traffic-measure-concept component was being instantiated as a TrackedArray, but DraggableObject expects an Ember array.

**Solution**: Modified `this.signs` to ensure it passes an Ember array to DraggableObject for compatibility.

Function that was throwing the error:
https://github.com/adopted-ember-addons/ember-drag-drop/blob/main/ember-drag-drop/src/services/drag-coordinator.js#L14