### PR TITLE
variables: use `label` instead of `value`

### DIFF
--- a/.changeset/fresh-mangos-thank.md
+++ b/.changeset/fresh-mangos-thank.md
@@ -1,0 +1,5 @@
+---
+"mow-registry": patch
+---
+
+Variables: replace instances of `value` attribute by `label`

--- a/app/components/add-instruction.hbs
+++ b/app/components/add-instruction.hbs
@@ -76,7 +76,7 @@
           <tbody>
             {{#each this.variables as |variable|}}
               <tr>
-                <td>{{variable.value}}</td>
+                <td>{{variable.label}}</td>
                 {{! template-lint-disable no-inline-styles }}
                 <td style="width: 50%;">
                   <PowerSelect

--- a/app/components/add-instruction.js
+++ b/app/components/add-instruction.js
@@ -122,7 +122,7 @@ export default class AddInstructionComponent extends Component {
       //search regex results if they contain this variable
       if (
         filteredRegexResult.find((fReg) => {
-          if (fReg[1] === variable.value) {
+          if (fReg[1] === variable.label) {
             return true;
           }
         })
@@ -133,11 +133,11 @@ export default class AddInstructionComponent extends Component {
       }
     });
 
-    //add new variable values
+    //add new variables
     filteredRegexResult.forEach((reg) => {
-      if (!this.variables.find((variable) => variable.value === reg[1])) {
+      if (!this.variables.find((variable) => variable.label === reg[1])) {
         const variable = this.store.createRecord('variable', {
-          value: reg[1],
+          label: reg[1],
           type: 'text',
         });
         this.variables.push(variable);
@@ -149,7 +149,7 @@ export default class AddInstructionComponent extends Component {
     this.variables.forEach((variable) => {
       if (
         !filteredVariables.find(
-          (fVariable) => fVariable.value === variable.value,
+          (fVariable) => fVariable.label === variable.label,
         )
       ) {
         filteredVariables.push(variable);
@@ -162,7 +162,7 @@ export default class AddInstructionComponent extends Component {
     const sortedVariables = [];
     filteredRegexResult.forEach((reg) => {
       filteredVariables.forEach((variable) => {
-        if (reg[1] == variable.value) {
+        if (reg[1] == variable.label) {
           sortedVariables.push(variable);
         }
       });
@@ -171,7 +171,7 @@ export default class AddInstructionComponent extends Component {
     //check existing default variables with deleted non-default variables and swap them
     sortedVariables.forEach((sVariable, sI) => {
       this.variablesToBeDeleted.forEach((dVariable, dI) => {
-        if (sVariable.value === dVariable.value) {
+        if (sVariable.label === dVariable.label) {
           if (dVariable.type !== 'text' && sVariable.type === 'text') {
             sortedVariables.replace(sI, 1, [dVariable]);
             this.variablesToBeDeleted.replace(dI, 1, [sVariable]);

--- a/app/components/instruction-manager.hbs
+++ b/app/components/instruction-manager.hbs
@@ -90,7 +90,7 @@
           <:body>
             {{#each this.variables as |variable|}}
               <tr>
-                <td>{{variable.value}}</td>
+                <td>{{variable.label}}</td>
                 <td>
                   <PowerSelect
                     @allowClear={{false}}

--- a/app/components/road-sign-form/variable-manager.hbs
+++ b/app/components/road-sign-form/variable-manager.hbs
@@ -18,11 +18,11 @@
               <tr>
                 <td>
                   <AuInput
-                    value={{variable.value}}
-                    @error={{variable.error.value}}
-                    {{on "input" (fn this.setVariableValue variable)}}
+                    value={{variable.label}}
+                    @error={{variable.error.label}}
+                    {{on "input" (fn this.setVariableLabel variable)}}
                   />
-                  <ErrorMessage @error={{variable.error.value}} />
+                  <ErrorMessage @error={{variable.error.label}} />
                 </td>
                 {{! template-lint-disable no-inline-styles }}
                 <td style="width: 50%;">

--- a/app/components/road-sign-form/variable-manager.ts
+++ b/app/components/road-sign-form/variable-manager.ts
@@ -68,9 +68,9 @@ export default class VariableManager extends Component<Signature> {
   }
 
   @action
-  setVariableValue(variable: Variable, event: InputEvent) {
-    const newValue = (event.target as HTMLInputElement).value;
-    variable.set('value', newValue);
+  setVariableLabel(variable: Variable, event: InputEvent) {
+    const newLabel = (event.target as HTMLInputElement).value;
+    variable.set('label', newLabel);
   }
 
   @action

--- a/app/components/traffic-measure-template.ts
+++ b/app/components/traffic-measure-template.ts
@@ -32,7 +32,7 @@ export default class TrafficMeasureTemplateComponent extends Component<Args> {
           (instruction?.value ?? '') +
           '</span>';
         preview = preview.replaceAll(
-          '${' + (variable.value ?? '') + '}',
+          '${' + (variable.label ?? '') + '}',
           replaceString,
         );
       }

--- a/app/components/traffic-measure/index.hbs
+++ b/app/components/traffic-measure/index.hbs
@@ -66,7 +66,7 @@
             {{t "utility.zonality"}}
           </AuHeading>
           {{#let (load @trafficMeasureConcept.zonality) as |zonality|}}
-            {{#if zonality.isResolved}} 
+            {{#if zonality.isResolved}}
               <ZonalitySelector
                 @zonality={{zonality.value}}
                 @onChange={{fn (mut @trafficMeasureConcept.zonality)}}
@@ -160,7 +160,7 @@
                 <tbody>
                   {{#each this.variables as |variable|}}
                     <tr>
-                      <td>{{variable.value}}</td>
+                      <td>{{variable.label}}</td>
                       {{! template-lint-disable no-inline-styles }}
                       <td style="width: 50%;">
                         <PowerSelect

--- a/app/components/traffic-measure/index.ts
+++ b/app/components/traffic-measure/index.ts
@@ -282,7 +282,7 @@ export default class TrafficMeasureIndexComponent extends Component<Args> {
       //search regex results if they contain this variable
       if (
         filteredRegexResult.find((fReg) => {
-          if (fReg[1] === variable.value) {
+          if (fReg[1] === variable.label) {
             return true;
           } else {
             return false;
@@ -298,10 +298,10 @@ export default class TrafficMeasureIndexComponent extends Component<Args> {
 
     //add new variable variables
     filteredRegexResult.forEach((reg) => {
-      if (!this.variables.find((variable) => variable.value === reg[1])) {
+      if (!this.variables.find((variable) => variable.label === reg[1])) {
         this.variables.push(
           this.store.createRecord<Variable>('variable', {
-            value: reg[1],
+            label: reg[1],
             type: 'text',
           }),
         );
@@ -313,7 +313,7 @@ export default class TrafficMeasureIndexComponent extends Component<Args> {
     this.variables.forEach((variable) => {
       if (
         !filteredVariables.find(
-          (fVariable) => fVariable.value === variable.value,
+          (fVariable) => fVariable.label === variable.label,
         )
       ) {
         filteredVariables.push(variable);
@@ -326,7 +326,7 @@ export default class TrafficMeasureIndexComponent extends Component<Args> {
     const sortedVariables: Variable[] = [];
     filteredRegexResult.forEach((reg) => {
       filteredVariables.forEach((variable) => {
-        if (reg[1] == variable.value) {
+        if (reg[1] == variable.label) {
           sortedVariables.push(variable);
         }
       });
@@ -335,7 +335,7 @@ export default class TrafficMeasureIndexComponent extends Component<Args> {
     //check existing default variables with deleted non-default variables and swap them
     sortedVariables.forEach((sVariable, sI) => {
       this.variablesToBeDeleted.forEach((dVariable, dI) => {
-        if (sVariable.value === dVariable.value) {
+        if (sVariable.label === dVariable.label) {
           if (dVariable.type !== 'text' && sVariable.type === 'text') {
             // sortedVariables.replace(sI, 1, [dVariable]);
             sortedVariables[sI] = dVariable;
@@ -365,7 +365,7 @@ export default class TrafficMeasureIndexComponent extends Component<Args> {
           (instruction?.value ?? '') +
           '</span>';
         this.preview = this.preview.replaceAll(
-          '${' + (variable.value ?? '') + '}',
+          '${' + (variable.label ?? '') + '}',
           replaceString,
         );
       }

--- a/app/models/variable.ts
+++ b/app/models/variable.ts
@@ -13,9 +13,8 @@ export default class Variable extends Resource {
   //@ts-expect-error TS doesn't allow subclasses to redefine concrete types. We should try to remove the inheritance chain.
   declare [Type]: 'variable';
   @attr declare uri: string;
-  @attr declare label?: string;
   @attr declare type?: string;
-  @attr declare value?: string;
+  @attr declare label?: string;
   @attr declare defaultValue?: string;
 
   @belongsTo<CodeList>('code-list', { inverse: 'variables', async: true })
@@ -29,7 +28,6 @@ export default class Variable extends Resource {
       uri: validateStringOptional(),
       label: validateStringRequired(),
       type: validateStringRequired(),
-      value: validateStringRequired(),
       defaultValue: validateStringOptional(),
       codeList: validateBelongsToOptional(),
       template: validateBelongsToOptional(),

--- a/app/templates/road-sign-concepts/road-sign-concept.hbs
+++ b/app/templates/road-sign-concepts/road-sign-concept.hbs
@@ -107,7 +107,7 @@
               <ul>
                 {{#each @model.roadSignConcept.variables as |variable|}}
                   <li>
-                    {{variable.value}}
+                    {{variable.label}}
                   </li>
                 {{/each}}
               </ul>


### PR DESCRIPTION
## Overview
This PR includes a refactor where the variable `value` attribute has been replaced by the more correct `label` attribute.

##### connected issues and PRs:
https://github.com/lblod/app-mow-registry/pull/108
https://github.com/lblod/fix-annotation-service/pull/16

### How to test/reproduce
Check-out https://github.com/lblod/app-mow-registry/pull/108

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint