### PR TITLE
feat(templates): introduce support for template previews

### DIFF
--- a/.changeset/cuddly-ladybugs-hang.md
+++ b/.changeset/cuddly-ladybugs-hang.md
@@ -1,0 +1,5 @@
+---
+"mow-registry": minor
+---
+
+Remove no longer supported `annotated` property on `Template` model

--- a/.changeset/yellow-gorillas-care.md
+++ b/.changeset/yellow-gorillas-care.md
@@ -1,0 +1,5 @@
+---
+"mow-registry": minor
+---
+
+Add `preview` property to `Template` model and adjust search-field

--- a/app/models/template.ts
+++ b/app/models/template.ts
@@ -20,7 +20,7 @@ export default class Template extends Document {
   //@ts-expect-error TS doesn't allow subclasses to redefine concrete types. We should try to remove the inheritance chain.
   declare [Type]: 'template';
   @attr declare value?: string;
-  @attr declare annotated?: string;
+  @attr declare preview?: string;
 
   @hasMany<Variable>('variable', { inverse: null, async: true })
   declare variables: AsyncHasMany<Variable>;
@@ -36,7 +36,7 @@ export default class Template extends Document {
       value: validateStringRequired(),
       variables: validateHasManyOptional(),
       parentConcept: validateBelongsToOptional(),
-      annotated: validateStringOptional(),
+      preview: validateStringOptional(),
     });
   }
 }

--- a/app/routes/traffic-measure-concepts/index.ts
+++ b/app/routes/traffic-measure-concepts/index.ts
@@ -37,7 +37,7 @@ export default class TrafficMeasureConceptsIndexRoute extends Route {
     }
 
     if (params.templateValue) {
-      query['filter[template][annotated]'] = params.templateValue;
+      query['filter[template][preview]'] = params.templateValue;
     }
 
     const result = await this.store.query<TrafficMeasureConcept>(


### PR DESCRIPTION
## Overview
This PR includes support for template previews.
Specifically:
- The `annotated` property of the `Template` model has been removed
- A `preview` property has been added to the `Template` model
- Users may now search on that `preview` property

##### connected issues and PRs:
https://github.com/lblod/app-mow-registry/pull/109
https://github.com/lblod/fix-annotation-service/pull/17

### How to test/reproduce
Check-out https://github.com/lblod/app-mow-registry/pull/109

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations