### PR TITLE
Add required UI to variables

### DIFF
--- a/app/components/road-sign-form/variable-manager.hbs
+++ b/app/components/road-sign-form/variable-manager.hbs
@@ -9,6 +9,7 @@
           <:header>
             <tr>
               <th>{{t "utility.variable"}}</th>
+              <th>{{t "utility.required"}}</th>
               <th>{{t "utility.type"}}</th>
               <th></th>
             </tr>
@@ -25,7 +26,16 @@
                   <ErrorMessage @error={{variable.error.label}} />
                 </td>
                 {{! template-lint-disable no-inline-styles }}
-                <td style="width: 50%;">
+                <td style="width: 33%;">
+                  <AuCheckbox
+                    @value={{variable.required}}
+                    @checked={{variable.required}}
+                    @onChange={{fn this.setVariableRequired variable}}
+                  >
+                    {{t "utility.required"}}
+                  </AuCheckbox>
+                </td>
+                <td style="width: 33%;">
                   <div
                     class={{if variable.error.type "ember-power-select--error"}}
                   >

--- a/app/components/road-sign-form/variable-manager.ts
+++ b/app/components/road-sign-form/variable-manager.ts
@@ -74,6 +74,11 @@ export default class VariableManager extends Component<Signature> {
   }
 
   @action
+  setVariableRequired(variable: Variable) {
+    variable.set('required', !variable.required);
+  }
+
+  @action
   async setVariableType(variable: Variable, selectedType: InputType) {
     if (variable.type === 'codelist') {
       //@ts-expect-error currently the ts types don't allow direct assignment of relationships

--- a/app/components/traffic-measure/index.hbs
+++ b/app/components/traffic-measure/index.hbs
@@ -154,6 +154,7 @@
                 <thead class="au-c-data-table__header">
                   <tr>
                     <th>{{t "traffic-measure-concept.attr.variable"}}</th>
+                    <th>{{t "utility.required"}}</th>
                     <th>{{t "traffic-measure-concept.attr.type"}}</th>
                   </tr>
                 </thead>
@@ -162,7 +163,16 @@
                     <tr>
                       <td>{{variable.label}}</td>
                       {{! template-lint-disable no-inline-styles }}
-                      <td style="width: 50%;">
+                      <td style="width: 33%;">
+                        <AuCheckbox
+                          @value={{variable.required}}
+                          @checked={{variable.required}}
+                          @onChange={{fn this.updateVariableRequired variable}}
+                        >
+                          {{t "utility.required"}}
+                        </AuCheckbox>
+                      </td>
+                      <td style="width: 33%;">
                         <PowerSelect
                           @allowClear={{false}}
                           @searchEnabled={{false}}

--- a/app/components/traffic-measure/index.ts
+++ b/app/components/traffic-measure/index.ts
@@ -232,6 +232,11 @@ export default class TrafficMeasureIndexComponent extends Component<Args> {
   }
 
   @action
+  async updateVariableRequired(variable: Variable) {
+    variable.set('required', !variable.required);
+  }
+
+  @action
   async updateVariableType(
     variable: Variable,
     selectedType: InputType | string,

--- a/app/models/variable.ts
+++ b/app/models/variable.ts
@@ -7,6 +7,7 @@ import {
   validateBelongsToOptional,
   validateStringOptional,
   validateStringRequired,
+  validateBooleanRequired,
 } from 'mow-registry/validators/schema';
 
 export default class Variable extends Resource {
@@ -16,6 +17,7 @@ export default class Variable extends Resource {
   @attr declare type?: string;
   @attr declare label?: string;
   @attr declare defaultValue?: string;
+  @attr({ defaultValue: true }) declare required?: boolean;
 
   @belongsTo<CodeList>('code-list', { inverse: 'variables', async: true })
   declare codeList: AsyncBelongsTo<CodeList>;
@@ -29,6 +31,7 @@ export default class Variable extends Resource {
       label: validateStringRequired(),
       type: validateStringRequired(),
       defaultValue: validateStringOptional(),
+      required: validateBooleanRequired(),
       codeList: validateBelongsToOptional(),
       template: validateBelongsToOptional(),
     });


### PR DESCRIPTION
## Overview
The user can now set variables as required or not

##### connected issues and PRs:
GN-5437


### Setup
None

### How to test/reproduce
Go to a road sign or a traffic measure and check that you can set your variables as required or not required (they should be required by default)
### Challenges/uncertainties
Not an expert on MOW (yet), so I might be missing some context, or some place where the variables are used.



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations