### PR TITLE
Fix: variable name no longer changes on selecting variable type if it was modified before

### DIFF
--- a/.changeset/strong-gorillas-begin.md
+++ b/.changeset/strong-gorillas-begin.md
@@ -1,0 +1,5 @@
+---
+"mow-registry": patch
+---
+
+Fix: variable name no longer changes on selecting variable type if it was modified before

--- a/app/components/road-sign-form/variable-manager.ts
+++ b/app/components/road-sign-form/variable-manager.ts
@@ -80,12 +80,18 @@ export default class VariableManager extends Component<Signature> {
 
   @action
   async setVariableType(variable: Variable, selectedType: InputType) {
+    const actualType = this.variableTypes.find(
+      (type) => type.value === variable.type,
+    );
+    const labelMofied = actualType && actualType.label !== variable.label;
     if (variable.type === 'codelist') {
       //@ts-expect-error currently the ts types don't allow direct assignment of relationships
       variable.codeList = this.codeLists[0];
     }
     variable.set('type', selectedType.value);
-    variable.set('label', selectedType.label);
+    if (!labelMofied) {
+      variable.set('label', selectedType.label);
+    }
   }
 
   @action


### PR DESCRIPTION

## Overview
Before setting the variable name to the type selected check if it was modified before by the user

##### connected issues and PRs:
GN-5472


### Setup
None

### How to test/reproduce
Go to a sign, edit it, check that if you don't modify the variable name it gets changed on type change, but as soon as you change that name to something else you can change the type without changing the label

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations