### PR TITLE
Add validation to traffic measures

### DIFF
--- a/.changeset/beige-experts-grow.md
+++ b/.changeset/beige-experts-grow.md
@@ -1,0 +1,5 @@
+---
+"mow-registry": minor
+---
+
+Add validation to traffic measures

--- a/app/components/traffic-measure/add-sign.ts
+++ b/app/components/traffic-measure/add-sign.ts
@@ -9,9 +9,11 @@ import TrafficSignConcept from 'mow-registry/models/traffic-sign-concept';
 import type RoadSignConcept from 'mow-registry/models/road-sign-concept';
 import type RoadMarkingConcept from 'mow-registry/models/road-marking-concept';
 import type TrafficLightConcept from 'mow-registry/models/traffic-light-concept';
+import { isSome } from 'mow-registry/utils/option';
 
 type Args = {
   selectedType: SignType;
+  selectedValidation?: string | null;
   addSign: (sign: TrafficSignConcept) => void;
 };
 export default class TrafficMeasureAddSignComponent extends Component<Args> {
@@ -26,6 +28,15 @@ export default class TrafficMeasureAddSignComponent extends Component<Args> {
     queryParams[this.args.selectedType.searchFilter] = searchData;
     queryParams['sort'] = this.args.selectedType.sortingField;
     queryParams['include'] = 'hasInstructions';
+
+    if (isSome(this.args.selectedValidation)) {
+      if (this.args.selectedValidation === 'true') {
+        queryParams['filter[valid]'] = true;
+      } else {
+        queryParams['filter[:or:][:has-no:valid]'] = 'yes';
+        queryParams['filter[:or:][valid]'] = false;
+      }
+    }
 
     const options = await this.store.query<
       RoadSignConcept | RoadMarkingConcept | TrafficLightConcept

--- a/app/components/traffic-measure/index.hbs
+++ b/app/components/traffic-measure/index.hbs
@@ -128,15 +128,28 @@
         {{t "traffic-measure-concept.attr.traffic-sign"}}
       </AuHeading>
       <div class="au-o-grid au-o-grid--tiny">
-        <div class="au-o-grid__item au-u-1-3@medium">
+        <div class="au-o-grid__item au-u-1-4@medium">
           <TrafficMeasure::SelectType
             @selectedType={{this.selectedType}}
             @updateTypeFilter={{this.updateTypeFilter}}
           />
         </div>
-        <div class="au-o-grid__item au-u-2-3@medium">
+        <div class="au-o-grid__item au-u-1-4@medium">
+          <PowerSelect
+            @allowClear={{true}}
+            @options={{this.validationStatusOptions}}
+            @selected={{this.selectedValidationStatus}}
+            @placeholder={{t "traffic-measure-concept.crud.validation-filter"}}
+            @onChange={{this.updateValidationFilter}}
+            as |validationType|
+          >
+            {{validationType.label}}
+          </PowerSelect>
+        </div>
+        <div class="au-o-grid__item au-u-2-4@medium">
           <TrafficMeasure::AddSign
             @selectedType={{this.selectedType}}
+            @selectedValidation={{this.signValidation}}
             @addSign={{this.addSign}}
             @disabled={{this.isSelectedTypeEmpty}}
           />

--- a/app/components/traffic-measure/index.hbs
+++ b/app/components/traffic-measure/index.hbs
@@ -139,7 +139,7 @@
             @allowClear={{true}}
             @options={{this.validationStatusOptions}}
             @selected={{this.selectedValidationStatus}}
-            @placeholder={{t "traffic-measure-concept.crud.validation-filter"}}
+            @placeholder={{t "traffic-measure-concept.crud.validation-filter-placeholder"}}
             @onChange={{this.updateValidationFilter}}
             as |validationType|
           >

--- a/app/components/traffic-measure/index.ts
+++ b/app/components/traffic-measure/index.ts
@@ -49,6 +49,7 @@ export default class TrafficMeasureIndexComponent extends Component<Args> {
   @tracked inputTypes: InputType[];
   @tracked instructionType: InputType;
   @tracked signsError = false;
+  @tracked signValidation?: string | null;
 
   variablesToBeDeleted: Variable[] = [];
 
@@ -81,6 +82,30 @@ export default class TrafficMeasureIndexComponent extends Component<Args> {
       value: 'instruction',
       label: this.intl.t('utility.template-variables.instruction'),
     };
+  }
+
+  get validationStatusOptions() {
+    return [
+      { value: 'true', label: this.intl.t('validation-status.valid') },
+      { value: 'false', label: this.intl.t('validation-status.draft') },
+    ];
+  }
+
+  get selectedValidationStatus() {
+    return this.validationStatusOptions.find(
+      (option) => option.value === this.signValidation,
+    );
+  }
+
+  @action
+  updateValidationFilter(
+    selectedOption: (typeof this.validationStatusOptions)[number],
+  ) {
+    if (selectedOption) {
+      this.signValidation = selectedOption.value;
+    } else {
+      this.signValidation = null;
+    }
   }
 
   @action

--- a/app/routes/traffic-measure-concepts/index.ts
+++ b/app/routes/traffic-measure-concepts/index.ts
@@ -12,6 +12,7 @@ type Params = {
   size: number;
   sort: string;
   templateValue: string;
+  validation?: string;
   validityOption?: string;
   validityStartDate?: string;
   validityEndDate?: string;
@@ -26,6 +27,7 @@ export default class TrafficMeasureConceptsIndexRoute extends Route {
     size: { refreshModel: true },
     sort: { refreshModel: true },
     templateValue: { refreshModel: true },
+    validation: { refreshModel: true },
     validityOption: { refreshModel: true },
     validityStartDate: { refreshModel: true },
     validityEndDate: { refreshModel: true },

--- a/app/templates/traffic-measure-concepts/index.hbs
+++ b/app/templates/traffic-measure-concepts/index.hbs
@@ -37,14 +37,14 @@
         </AuFormRow>
          <div>
           <AuLabel for="validation-filter">
-            {{t "traffic-light-concept.crud.validation-filter"}}
+            {{t "traffic-measure-concept.crud.validation-filter"}}
           </AuLabel>
           <PowerSelect
             @allowClear={{true}}
             @options={{this.validationStatusOptions}}
             @selected={{this.selectedValidationStatus}}
             @placeholder={{t
-              "traffic-light-concept.crud.validation-filter-placeholder"
+              "traffic-measure-concept.crud.validation-filter-placeholder"
             }}
             @loadingMessage={{t "utility.loading"}}
             @onChange={{this.updateValidationFilter}}

--- a/app/templates/traffic-measure-concepts/index.hbs
+++ b/app/templates/traffic-measure-concepts/index.hbs
@@ -35,6 +35,25 @@
             {{on "input" (perform this.updateSearchFilterTask "templateFilter")}}
           />
         </AuFormRow>
+         <div>
+          <AuLabel for="validation-filter">
+            {{t "traffic-light-concept.crud.validation-filter"}}
+          </AuLabel>
+          <PowerSelect
+            @allowClear={{true}}
+            @options={{this.validationStatusOptions}}
+            @selected={{this.selectedValidationStatus}}
+            @placeholder={{t
+              "traffic-light-concept.crud.validation-filter-placeholder"
+            }}
+            @loadingMessage={{t "utility.loading"}}
+            @onChange={{this.updateValidationFilter}}
+            @triggerId="validation-filter"
+            as |validation|
+          >
+            {{validation.label}}
+          </PowerSelect>
+        </div>
         <ValidityFilters
           @onChange={{this.updateValidityFilter}}
           @value={{this.validityOption}}

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -249,6 +249,8 @@ traffic-measure-concept:
     type-filter: Filter by type
     no-matches: No results found
     type-to-search: Type to search
+    validation-filter: Validation
+    validation-filter-placeholder: Filter by validation status
   landing-page:
     content: Manage traffic measures.
     button: Go to traffic measures

--- a/translations/nl-be.yaml
+++ b/translations/nl-be.yaml
@@ -240,6 +240,8 @@ traffic-measure-concept:
     type-filter: Filteren op type
     no-matches: Geen resultaten gevonden
     type-to-search: Typ om te zoeken
+    validation-filter: Validatie
+    validation-filter-placeholder: Filteren op validatie-status
   landing-page:
     content: Beheer mobiliteitsmaatregelen.
     button: Ga naar Mobiliteitsmaatregelen


### PR DESCRIPTION
## Overview
Add validation filters to measures, both in the list page and in the new/edit page when adding signs.
I based my PR on the validity dates because I changed the way we are fetching measures.

##### connected issues and PRs:
GN-5476


### Setup
None

### How to test/reproduce
Go to the traffic measures page, notice you can filter on validation status, and then edit a measure so you can also filter on the validation status of the traffic signs to attach to that measure 

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations