### PR TITLE
Validity dates datepicker minimum

### DIFF
--- a/.changeset/fresh-hounds-fail.md
+++ b/.changeset/fresh-hounds-fail.md
@@ -1,0 +1,7 @@
+---
+"mow-registry": minor
+---
+
+Validity dates: set start-date as minimum for end-date date-picker.
+This ensures users are not able to select a date lower than the start-date.
+Additionally, they do not need to navigate back to the same month/year, which should slightly improve UX.

--- a/app/components/instruction-manager.hbs
+++ b/app/components/instruction-manager.hbs
@@ -103,6 +103,7 @@
                 @error={{error}}
                 @warning={{warning}}
                 id="endDate"
+                @min={{this.template.startDate}}
                 @value={{this.template.endDate}}
                 @onChange={{fn this.setTemplateDate 'endDate'}}
               />

--- a/app/components/road-marking-form.hbs
+++ b/app/components/road-marking-form.hbs
@@ -164,6 +164,7 @@
               @error={{error}}
               @warning={{warning}}
               id="endDate"
+              @min={{@roadMarkingConcept.startDate}}
               @value={{@roadMarkingConcept.endDate}}
               @onChange={{fn this.setRoadMarkingDate 'endDate'}}
             />

--- a/app/components/road-sign-form.hbs
+++ b/app/components/road-sign-form.hbs
@@ -155,6 +155,7 @@
               @error={{error}}
               @warning={{warning}}
               id="endDate"
+              @min={{@roadSignConcept.startDate}}
               @value={{@roadSignConcept.endDate}}
               @onChange={{fn this.setRoadsignDate 'endDate'}}
             />

--- a/app/components/traffic-light-form.hbs
+++ b/app/components/traffic-light-form.hbs
@@ -164,6 +164,7 @@
               @error={{error}}
               @warning={{warning}}
               id="endDate"
+              @min={{@trafficLightConcept.startDate}}
               @value={{@trafficLightConcept.endDate}}
               @onChange={{fn this.setTrafficLightDate 'endDate'}}
             />

--- a/app/components/traffic-measure/index.hbs
+++ b/app/components/traffic-measure/index.hbs
@@ -114,6 +114,7 @@
               @error={{error}}
               @warning={{warning}}
               id="endDate"
+              @min={{@trafficMeasureConcept.startDate}}
               @value={{@trafficMeasureConcept.endDate}}
               @onChange={{fn this.setTrafficMeasureDate 'endDate'}}
             />

--- a/app/components/validity-filters.gts
+++ b/app/components/validity-filters.gts
@@ -98,6 +98,7 @@ export default class ValidityFilters extends Component {
       </AuLabel>
       <AuDatePicker
         id="endDate"
+        @min={{convertToDate @startDate}}
         @value={{convertToDate @endDate}}
         @onChange={{this.setEndDate}}
       />


### PR DESCRIPTION
## Overview
This PR sets the start-date (if it is defined) as the minimum for the end-date date-picker.
This ensures users are not able to select a date lower then the start-date.
Additionally, they do not need to navigate back to the same month/year, which should slightly improve UX.

### How to test/reproduce
- Start the app
- Open a roadsign-concept (or other concept)
- Select a start-date
- Open the end-date datepicker: you should not be able to select a date lower than the start-date
- When opening the end-date datepicker, it is initialized with the month + year of the start-date (if defined)
