### PR TITLE
Fix table count not being correct sometimes

### DIFF
--- a/.changeset/great-geese-lay.md
+++ b/.changeset/great-geese-lay.md
@@ -1,0 +1,5 @@
+---
+"mow-registry": patch
+---
+
+Fix: the table total number of items was wrong sometimes

--- a/app/utils/fetch-manual-data.ts
+++ b/app/utils/fetch-manual-data.ts
@@ -145,7 +145,7 @@ export default async function fetchManualData(
   `;
   const queryCount = `
     ${PREFIXES}
-    SELECT (count( ?id) as ?count)  WHERE {
+    SELECT (count( DISTINCT ?id) as ?count)  WHERE {
       ${queryContent}
     }
 `;


### PR DESCRIPTION
## Overview
Fixed problem with the count query not being correct sometimes, due to duplicate ids in the query result

##### connected issues and PRs:
GN-5571

### Setup
None

### How to test/reproduce
Check the linked ticket, the bug should not happen anymore with the PR, basically some queries resulted in duplicated results in the count query and the total count of items was more than the actual count

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations