### PR TITLE
Correctly wire `templateValue` query param

### DIFF
--- a/.changeset/fast-stingrays-wink.md
+++ b/.changeset/fast-stingrays-wink.md
@@ -1,0 +1,5 @@
+---
+"mow-registry": patch
+---
+
+Traffic measure concepts: correctly wire `templateValue` filter

--- a/app/controllers/traffic-measure-concepts/index.ts
+++ b/app/controllers/traffic-measure-concepts/index.ts
@@ -95,6 +95,7 @@ export default class TrafficMeasureConceptsIndexController extends Controller {
         page: this.page,
         size: this.size,
         label: this.label,
+        templateValue: this.templateValue,
         sort: this.sort,
         validation: this.validation,
         validityOption: this.validityOption,


### PR DESCRIPTION
## Overview
This PR ensures that the `templateValue` query parameter is correctly used to filter the traffic measure concepts.

### How to test/reproduce
- Start the app
- Open the traffic measure concepts index page
- Ensure filtering on the content of a template works as expected

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint