### PR TITLE
GN-5565: traffic-measure form - correctly update error state after fixing issues

### DIFF
--- a/.changeset/fair-mails-lie.md
+++ b/.changeset/fair-mails-lie.md
@@ -1,0 +1,5 @@
+---
+"mow-registry": patch
+---
+
+Traffic-measure form: ensure error state is correctly updated after fixing form errors

--- a/app/components/traffic-measure/index.hbs
+++ b/app/components/traffic-measure/index.hbs
@@ -69,7 +69,7 @@
             {{#if zonality.isResolved}}
               <ZonalitySelector
                 @zonality={{zonality.value}}
-                @onChange={{fn (mut @trafficMeasureConcept.zonality)}}
+                @onChange={{this.updateZonality}}
                 @trafficMeasureConcept={{@trafficMeasureConcept}}
               />
             {{/if}}

--- a/app/components/traffic-measure/index.ts
+++ b/app/components/traffic-measure/index.ts
@@ -22,6 +22,7 @@ import Variable from 'mow-registry/models/variable';
 import { removeItem } from 'mow-registry/utils/array';
 import { TrackedArray } from 'tracked-built-ins';
 import validateTrafficMeasureDates from 'mow-registry/utils/validate-traffic-measure-dates';
+import type SkosConcept from 'mow-registry/models/skos-concept';
 
 export type InputType = {
   value: string;
@@ -95,6 +96,12 @@ export default class TrafficMeasureIndexComponent extends Component<Args> {
     return this.validationStatusOptions.find(
       (option) => option.value === this.signValidation,
     );
+  }
+
+  @action
+  async updateZonality(zonality: SkosConcept) {
+    this.trafficMeasureConcept.set('zonality', zonality);
+    await this.trafficMeasureConcept.validateProperty('zonality');
   }
 
   @action
@@ -233,9 +240,10 @@ export default class TrafficMeasureIndexComponent extends Component<Args> {
   }
 
   @action
-  updateTemplate(event: InputEvent) {
+  async updateTemplate(event: InputEvent) {
     if (this.template) {
       this.template.value = (event.target as HTMLInputElement).value;
+      await this.template.validate();
     }
   }
 


### PR DESCRIPTION
## Overview
This PR ensures that the joi validation function is correctly run when updating either the template or zonality of a traffic measure concept.

##### connected issues and PRs:
[GN-5565](https://binnenland.atlassian.net/browse/GN-5565?atlOrigin=eyJpIjoiZDIxZmI2MjJlMDU4NGE4MDliNDBmNDMxNGU0ZWExNGIiLCJwIjoiaiJ9)

### How to test/reproduce
- Start the app
- Open the traffic measure overview
- Open the form by editing/adding a traffic measure
- Submit without any fields filled in
- Fix the form errors. The error messages should disappear accordingly

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations