### PR TITLE
Remove redundant breadcrumb entries

### DIFF
--- a/.changeset/shaggy-flowers-hide.md
+++ b/.changeset/shaggy-flowers-hide.md
@@ -1,0 +1,5 @@
+---
+"mow-registry": patch
+---
+
+Remove some unnecessary/redundant breadcrumb entries

--- a/app/templates/road-marking-concepts/road-marking-concept/instructions.hbs
+++ b/app/templates/road-marking-concepts/road-marking-concept/instructions.hbs
@@ -1,11 +1,2 @@
 {{page-title (t "utility.instructions")}}
-<BreadcrumbsItem as |linkClass|>
-  <LinkTo
-    @route="road-marking-concepts.road-marking-concept.instructions"
-    class={{linkClass}}
-  >
-    {{t "utility.instructions"}}
-  </LinkTo>
-</BreadcrumbsItem>
-
 {{outlet}}

--- a/app/templates/road-marking-concepts/road-marking-concept/instructions/edit.hbs
+++ b/app/templates/road-marking-concepts/road-marking-concept/instructions/edit.hbs
@@ -1,6 +1,5 @@
 {{#let (if this.model.template false true) as |isNew|}}
   {{page-title (if isNew (t "utility.add-instruction") (t "utility.edit-instruction"))}}
-
   <BreadcrumbsItem as |linkClass|>
     <LinkTo
       @route="road-marking-concepts.road-marking-concept.instructions.edit"

--- a/app/templates/road-marking-concepts/road-marking-concept/related.hbs
+++ b/app/templates/road-marking-concepts/road-marking-concept/related.hbs
@@ -1,12 +1,4 @@
 {{page-title (t "utility.related-traffic-signs")}}
-<BreadcrumbsItem as |linkClass|>
-  <LinkTo
-    @route="road-marking-concepts.road-marking-concept.related"
-    class={{linkClass}}
-  >
-    {{t "utility.related-traffic-signs"}}
-  </LinkTo>
-</BreadcrumbsItem>
 
 <RoadMarkingConcept::Header @roadMarkingConcept={{@model.roadMarkingConcept}} />
 

--- a/app/templates/road-sign-concepts/road-sign-concept/instructions.hbs
+++ b/app/templates/road-sign-concepts/road-sign-concept/instructions.hbs
@@ -1,11 +1,3 @@
 {{page-title (t "utility.instructions")}}
-<BreadcrumbsItem as |linkClass|>
-  <LinkTo
-    @route="road-sign-concepts.road-sign-concept.instructions"
-    class={{linkClass}}
-  >
-    {{t "utility.instructions"}}
-  </LinkTo>
-</BreadcrumbsItem>
 
 {{outlet}}

--- a/app/templates/road-sign-concepts/road-sign-concept/main-signs.hbs
+++ b/app/templates/road-sign-concepts/road-sign-concept/main-signs.hbs
@@ -1,12 +1,4 @@
 {{page-title (t "utility.main-signs")}}
-<BreadcrumbsItem as |linkClass|>
-  <LinkTo
-    @route="road-sign-concepts.road-sign-concept.main-signs"
-    class={{linkClass}}
-  >
-    {{t "utility.main-signs"}}
-  </LinkTo>
-</BreadcrumbsItem>
 
 <RoadSignConcept::Header @roadSignConcept={{@model.roadSignConcept}} />
 

--- a/app/templates/road-sign-concepts/road-sign-concept/related.hbs
+++ b/app/templates/road-sign-concepts/road-sign-concept/related.hbs
@@ -1,12 +1,4 @@
 {{page-title (t "utility.related-traffic-signs")}}
-<BreadcrumbsItem as |linkClass|>
-  <LinkTo
-    @route="road-sign-concepts.road-sign-concept.related"
-    class={{linkClass}}
-  >
-    {{t "utility.related-traffic-signs"}}
-  </LinkTo>
-</BreadcrumbsItem>
 
 <RoadSignConcept::Header @roadSignConcept={{@model.roadSignConcept}} />
 

--- a/app/templates/road-sign-concepts/road-sign-concept/sub-signs.hbs
+++ b/app/templates/road-sign-concepts/road-sign-concept/sub-signs.hbs
@@ -1,13 +1,4 @@
 {{page-title (t "utility.sub-signs")}}
-<BreadcrumbsItem as |linkClass|>
-  <LinkTo
-    @route="road-sign-concepts.road-sign-concept.sub-signs"
-    class={{linkClass}}
-  >
-    {{t "utility.sub-signs"}}
-  </LinkTo>
-</BreadcrumbsItem>
-
 <RoadSignConcept::Header @roadSignConcept={{@model.roadSignConcept}} />
 
 <SidebarOverlayContainer @isOpen={{this.isAddingSubSigns}}>

--- a/app/templates/traffic-light-concepts/traffic-light-concept/related.hbs
+++ b/app/templates/traffic-light-concepts/traffic-light-concept/related.hbs
@@ -1,12 +1,4 @@
 {{page-title (t "utility.related-traffic-signs")}}
-<BreadcrumbsItem as |linkClass|>
-  <LinkTo
-    @route="traffic-light-concepts.traffic-light-concept.related"
-    class={{linkClass}}
-  >
-    {{t "utility.related-traffic-signs"}}
-  </LinkTo>
-</BreadcrumbsItem>
 
 <TrafficLightConcept::Header @trafficLightConcept={{@model.trafficLightConcept}} />
 


### PR DESCRIPTION
## Overview
This PR removes some redundant breadcrumb entries on the following routes:
- `traffic-sign-concept`
- `road-marking-concept`
- `traffic-light-concept`

### How to test/reproduce
- Start the app
- Notice that, when visiting the detail page of a `traffic-sign-concept`/`road-marking-concept`/`traffic-light-concept`, there are no longer any redundant breadcrumb entries.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations