### PR TITLE
Update relationship in fetch manual data

### DIFF
--- a/.changeset/small-flowers-perform.md
+++ b/.changeset/small-flowers-perform.md
@@ -1,0 +1,5 @@
+---
+"mow-registry": patch
+---
+
+Fix bug where text filter didn't work on mobility measure

--- a/app/utils/fetch-manual-data.ts
+++ b/app/utils/fetch-manual-data.ts
@@ -138,7 +138,7 @@ export default async function fetchManualData(
       ?uri mobiliteit:ARplichtig ?ARplichtig.
     }
     OPTIONAL {
-      ?uri mobiliteit:template ?template.
+      ?uri mobiliteit:Mobiliteitsmaatregelconcept.template ?template.
       ?template ext:preview ?templatePreview.
     }
     ${filters.join(' ')}


### PR DESCRIPTION
## Overview
We forgot to update the template relationship in the fetch manual data function

##### connected issues and PRs:
GN-5641


### Setup
None

### How to test/reproduce
Go to the mobility measures and check you can now filter on the text of the measure without problems

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations