### PR TITLE
Add default shape to road signs and road markings

### DIFF
--- a/.changeset/early-trains-lick.md
+++ b/.changeset/early-trains-lick.md
@@ -1,0 +1,5 @@
+---
+"mow-registry": minor
+---
+
+Add control to set default shape to road signs and road markings

--- a/app/components/common/shape-manager.hbs
+++ b/app/components/common/shape-manager.hbs
@@ -2,8 +2,8 @@
   <f.legend
     @skin={{this.skin}}
     @required={{true}}
-    @requiredLabel={{this.requiredLabel}}
-    @error={{@roadSignConcept.error.shapes}}
+    @requiredLabel={{t "utility.required"}}
+    @error={{@trafficSignConcept.error.shapes}}
   >
     {{t "utility.shapes"}}
   </f.legend>
@@ -178,7 +178,7 @@
         {{t "road-sign-concept.add-shape"}}
       </AuButton>
 
-      <ErrorMessage @error={{@roadSignConcept.error.shapes}} />
+      <ErrorMessage @error={{@trafficSignConcept.error.shapes}} />
     </div>
   </f.content>
 </AuFieldset>

--- a/app/components/common/shape-manager.hbs
+++ b/app/components/common/shape-manager.hbs
@@ -35,7 +35,7 @@
             </AuToolbar>
           </c.header>
           <c.content>
-            <AuFormRow>
+            <AuFormRow @alignment="inline">
               <div
                 class="au-u-1-2
                   {{if shape.error.classification 'ember-power-select--error'}}"
@@ -53,6 +53,14 @@
                 >
                   {{shapeClassification.label}}
                 </PowerSelect>
+              </div>
+              <div class="au-u-1-2">
+                <AuCheckbox
+                  @checked={{eq shape.id @defaultShape.id}}
+                  @onChange={{fn @toggleDefaultShape shape}}
+                >
+                  {{t "road-sign-concept.attr.default-shape"}}
+                </AuCheckbox>
               </div>
               <ErrorMessage @error={{shape.error.classification}} />
             </AuFormRow>

--- a/app/components/common/shape-manager.ts
+++ b/app/components/common/shape-manager.ts
@@ -12,7 +12,7 @@ import type Unit from 'mow-registry/models/unit';
 
 interface Signature {
   Args: {
-    roadSignConcept: TrafficSignConcept;
+    trafficSignConcept: TrafficSignConcept;
     shapes: Shape[];
     addShape: () => void;
     removeShape: (shapeToRemove: Shape) => void;

--- a/app/components/common/shape-manager.ts
+++ b/app/components/common/shape-manager.ts
@@ -14,8 +14,11 @@ interface Signature {
   Args: {
     trafficSignConcept: TrafficSignConcept;
     shapes: Shape[];
+    defaultShape?: Shape;
     addShape: () => void;
+    toggleDefaultShape: (shape: Shape) => Promise<void>;
     removeShape: (shapeToRemove: Shape) => void;
+    removeDimension: (shape: Shape, dimensionToRemove: Dimension) => void;
   };
 }
 

--- a/app/components/road-marking-form.hbs
+++ b/app/components/road-marking-form.hbs
@@ -188,6 +188,8 @@
               @addShape={{this.addShape}}
               @removeShape={{this.removeShape}}
               @removeDimension={{this.removeDimension}}
+              @defaultShape={{@roadMarkingConcept.defaultShape}}
+              @toggleDefaultShape={{this.toggleDefaultShape}}
             />
           {{/if}}
         {{/let}}

--- a/app/components/road-sign-form.hbs
+++ b/app/components/road-sign-form.hbs
@@ -214,6 +214,8 @@
               @addShape={{this.addShape}}
               @removeShape={{this.removeShape}}
               @removeDimension={{this.removeDimension}}
+              @defaultShape={{@roadSignConcept.defaultShape}}
+              @toggleDefaultShape={{this.toggleDefaultShape}}
             />
           {{/if}}
         {{/let}}

--- a/app/models/traffic-sign-concept.ts
+++ b/app/models/traffic-sign-concept.ts
@@ -32,7 +32,7 @@ export default class TrafficSignConcept extends SkosConcept {
   @attr('date') declare startDate?: Date;
   @attr('date') declare endDate?: Date;
 
-  @hasMany('variable', {
+  @hasMany<Variable>('variable', {
     inverse: null,
     async: true,
   })
@@ -50,7 +50,7 @@ export default class TrafficSignConcept extends SkosConcept {
   })
   declare hasInstructions: AsyncHasMany<Template>;
 
-  @hasMany('tribont-shape', { inverse: null, async: true })
+  @hasMany<TribontShape>('tribont-shape', { inverse: null, async: true })
   declare shapes: AsyncHasMany<TribontShape>;
 
   @hasMany<TrafficMeasureConcept>('traffic-measure-concept', {

--- a/app/models/traffic-sign-concept.ts
+++ b/app/models/traffic-sign-concept.ts
@@ -53,6 +53,9 @@ export default class TrafficSignConcept extends SkosConcept {
   @hasMany<TribontShape>('tribont-shape', { inverse: null, async: true })
   declare shapes: AsyncHasMany<TribontShape>;
 
+  @belongsTo<TribontShape>('tribont-shape', { inverse: null, async: true })
+  declare defaultShape: AsyncBelongsTo<TribontShape>;
+
   @hasMany<TrafficMeasureConcept>('traffic-measure-concept', {
     async: true,
     inverse: 'relatedTrafficSignConcepts',
@@ -63,6 +66,7 @@ export default class TrafficSignConcept extends SkosConcept {
   get validationSchema() {
     return super.validationSchema.keys({
       shapes: validateHasManyOptional(),
+      defaultShape: validateBelongsToOptional(),
       valid: validateBooleanOptional(),
       arPlichtig: validateBooleanOptional(),
       startDate: validateDateOptional(),

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -112,6 +112,7 @@ road-sign-concept:
     related-traffic-light: Related traffic light
     shape: Shape
     dimensions: Dimensions
+    default-shape: Default shape
     height: Height
     width: Width
     radius: Radius

--- a/translations/nl-be.yaml
+++ b/translations/nl-be.yaml
@@ -111,6 +111,7 @@ road-sign-concept:
     related-traffic-light: Gerelateerde verkeerslichten
     shape: Vorm
     dimensions: Afmetingen
+    default-shape: Standaardvorm
     height: Hoogte
     width: Breedte
     radius: Straal


### PR DESCRIPTION
## Overview
I didn't think much about the UI as we'll be changing that anyway. I made some small corrections and tweaks which help with validation and loading time.

##### connected issues and PRs:
Requires updated resources config: https://github.com/lblod/app-mow-registry/pull/133
Jira ticket: https://binnenland.atlassian.net/browse/GN-5547

### Setup
To test functionality, needs to be tested with the app-mow PR.
To verify that it makes it to the LDES feed, setting up https://github.com/lblod/app-ldes-feed-visualizer is fairly easy, just need to connect the identifier to a shared network that the visualizer is on (note the BASE config, if you need to change this, you may already have LDES contents that are not valid, so you will have to clear them by deleting the files):
```
services:
  identifier:
    networks:
      default:
      shared-ldes:
        aliases:
          - mow-identifier
  ldes-delta-pusher:
    environment:
      LDES_BASE: "http://mow-identifier/"
  ldes-serve-feed:
    environment:
      BASE_URL: "http://mow-identifier/"
networks:
  shared-ldes:
    name: shared-ldes
    external: true
```
And on the visualizer side:
```
services:
  consumer:
    environment:
      LDES_ENDPOINT_VIEW: "http://mow-identifier/ldes-mow-register/1"
    networks:
      - default
      - shared-ldes
networks:
  shared-ldes:
    name: shared-ldes
```

### How to test/reproduce
You can CRUD the setting of which shape is the default and the data stays valid (including in the LDES feed).

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations