### PR TITLE
warp-drive: use new API

### DIFF
--- a/.changeset/wild-rockets-rescue.md
+++ b/.changeset/wild-rockets-rescue.md
@@ -1,0 +1,5 @@
+---
+"mow-registry": patch
+---
+
+Introduce usage of new `store.request` Warpdrive API, and migrate instances of: `findAll`, `findRecord` and `query` to the new syntax.

--- a/.changeset/wild-rockets-rescue.md
+++ b/.changeset/wild-rockets-rescue.md
@@ -2,4 +2,4 @@
 "mow-registry": patch
 ---
 
-Introduce usage of new `store.request` Warpdrive API, and migrate instances of: `findAll`, `findRecord` and `query` to the new syntax.
+Introduce usage of new `store.request` Warpdrive API, and migrate instances of: `findAll`, `findRecord`, `query` and `.save()` to the new syntax.

--- a/app/components/add-instruction.gts
+++ b/app/components/add-instruction.gts
@@ -43,6 +43,7 @@ import { isSome } from 'mow-registry/utils/option';
 import { removeItem } from 'mow-registry/utils/array';
 import validateTemplateDates from 'mow-registry/utils/validate-template-dates';
 import ErrorMessage from 'mow-registry/components/error-message';
+import { saveRecord } from '@warp-drive/legacy/compat/builders';
 
 export interface AddInstructionSig {
   Args: {
@@ -150,7 +151,7 @@ export default class AddInstructionComponent extends Component<AddInstructionSig
     removeItem(templates, template);
 
     await template.destroyRecord();
-    await this.args.concept.save();
+    await this.store.request(saveRecord(this.args.concept));
 
     this.router.replaceWith(this.args.from);
   });
@@ -291,17 +292,17 @@ export default class AddInstructionComponent extends Component<AddInstructionSig
       const areVariablesValid = await validateVariables(this.variables);
 
       if (isValid && areVariablesValid && !this.templateSyntaxError) {
-        await this.template.save();
+        await this.store.request(saveRecord(this.template));
         (await this.concept.hasInstructions).push(this.template);
-        await this.concept.save();
+        await this.store.request(saveRecord(this.concept));
         for (let i = 0; i < this.variables.length; i++) {
           const variable = this.variables[i];
           if (variable) {
             (await this.template.variables).push(variable);
-            await variable.save();
+            await this.store.request(saveRecord(variable));
           }
         }
-        await this.template.save();
+        await this.store.request(saveRecord(this.template));
         await Promise.all(
           this.variablesToBeDeleted.map((variable) => variable.destroyRecord()),
         );

--- a/app/components/codelist-form.ts
+++ b/app/components/codelist-form.ts
@@ -14,7 +14,7 @@ import type RouterService from '@ember/routing/router-service';
 import Icon from 'mow-registry/models/icon';
 import { removeItem } from 'mow-registry/utils/array';
 import type ConceptScheme from 'mow-registry/models/concept-scheme';
-import { findRecord } from '@warp-drive/legacy/compat/builders';
+import { findRecord, saveRecord } from '@warp-drive/legacy/compat/builders';
 
 type Args = {
   codelist: CodeList;
@@ -136,8 +136,10 @@ export default class CodelistFormComponent extends Component<Args> {
 
     if (!codelist.error) {
       await Promise.all(this.toDelete.map((option) => option.destroyRecord()));
-      await Promise.all(this.options.map((option) => option.save()));
-      await codelist.save();
+      await Promise.all(
+        this.options.map((option) => this.store.request(saveRecord(option))),
+      );
+      await this.store.request(saveRecord(codelist));
       await this.router.transitionTo(
         'codelists-management.codelist',
         codelist.id,

--- a/app/components/codelist-form.ts
+++ b/app/components/codelist-form.ts
@@ -14,6 +14,7 @@ import type RouterService from '@ember/routing/router-service';
 import Icon from 'mow-registry/models/icon';
 import { removeItem } from 'mow-registry/utils/array';
 import type ConceptScheme from 'mow-registry/models/concept-scheme';
+import { findRecord } from '@warp-drive/legacy/compat/builders';
 
 type Args = {
   codelist: CodeList;
@@ -52,10 +53,11 @@ export default class CodelistFormComponent extends Component<Args> {
   }
 
   fetchCodelistTypes = task(async () => {
-    const typesScheme = await this.store.findRecord<ConceptScheme>(
-      'concept-scheme',
-      COD_CONCEPT_SCHEME_ID,
-    );
+    const typesScheme = await this.store
+      .request(
+        findRecord<ConceptScheme>('concept-scheme', COD_CONCEPT_SCHEME_ID),
+      )
+      .then((res) => res.content);
     const types = await typesScheme.concepts;
     this.codelistTypes = types;
     if (await this.args.codelist.type) {

--- a/app/components/common/shape-manager.gts
+++ b/app/components/common/shape-manager.gts
@@ -35,6 +35,7 @@ import { isSome } from 'mow-registry/utils/option';
 import ErrorMessage from 'mow-registry/components/error-message';
 import sortByOrder from 'mow-registry/helpers/sort-by-order';
 import type { AsyncBelongsTo } from '@warp-drive/legacy/model';
+import { findAll, query } from '@warp-drive/legacy/compat/builders';
 
 interface Signature {
   Args: {
@@ -91,25 +92,31 @@ export default class ShapeManager extends Component<Signature> {
   }
 
   async fetchUnits() {
-    this.units = await this.store.findAll<Unit>('unit');
+    this.units = await this.store
+      .request(findAll<Unit>('unit'))
+      .then((res) => res.content);
 
     return this.units;
   }
 
   async fetchShapeClassifications() {
-    const classifications = await this.store.findAll<ShapeClassification>(
-      'tribont-shape-classification-code',
-    );
+    const classifications = await this.store
+      .request(
+        findAll<ShapeClassification>('tribont-shape-classification-code'),
+      )
+      .then((res) => res.content);
 
     return classifications;
   }
 
   fetchQuantityKinds() {
-    return this.store.query<QuantityKind>('quantity-kind', {
-      // @ts-expect-error we're running into strange type errors with the query argument. Not sure how to fix this properly.
-      // TODO: fix the query types
-      include: 'units',
-    });
+    return this.store
+      .request(
+        query<QuantityKind>('quantity-kind', {
+          include: ['units'],
+        }),
+      )
+      .then((res) => res.content);
   }
 
   addDimension = async (shape: TribontShape) => {

--- a/app/components/content-check.ts
+++ b/app/components/content-check.ts
@@ -1,13 +1,18 @@
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { saveRecord } from '@warp-drive/legacy/compat/builders';
 import { task } from 'ember-concurrency';
 import TrafficSignalConcept from 'mow-registry/models/traffic-signal-concept';
+import type Store from 'mow-registry/services/store';
 
 type Args = {
   concept: TrafficSignalConcept;
 };
 export default class ContentCheckComponent extends Component<Args> {
+  @service declare store: Store;
+
   update = task(async (value: boolean) => {
     this.args.concept.valid = value;
-    await this.args.concept.save();
+    await this.store.request(saveRecord(this.args.concept));
   });
 }

--- a/app/components/icon-catalog-form.ts
+++ b/app/components/icon-catalog-form.ts
@@ -4,12 +4,15 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { dropTask } from 'ember-concurrency';
 import Icon from 'mow-registry/models/icon';
+import { saveRecord } from '@warp-drive/legacy/compat/builders';
+import type Store from 'mow-registry/services/store';
 
 type Args = {
   icon: Icon;
 };
 export default class IconCatalogFormComponent extends ImageUploadHandlerComponent<Args> {
   @service declare router: RouterService;
+  @service declare store: Store;
 
   get isSaving() {
     return this.editIconTask.isRunning;
@@ -39,8 +42,8 @@ export default class IconCatalogFormComponent extends ImageUploadHandlerComponen
 
     if (!this.args.icon.error) {
       const imageRecord = await this.saveImage();
-      if (imageRecord) this.args.icon.set('image', imageRecord); // image gets updated, but not overwritten
-      await this.args.icon.save();
+      if (imageRecord) this.args.icon.set('image', imageRecord); // image gets updated, but not overwritten\
+      await this.store.request(saveRecord(this.args.icon));
 
       await this.router.transitionTo('icon-catalog.icon', this.args.icon.id);
     }

--- a/app/components/icon-select.ts
+++ b/app/components/icon-select.ts
@@ -5,6 +5,8 @@ import Store from 'mow-registry/services/store';
 import { tracked } from '@glimmer/tracking';
 import type Icon from 'mow-registry/models/icon';
 import { action } from '@ember/object';
+import { query } from '@warp-drive/legacy/compat/builders';
+import type { LegacyResourceQuery } from '@warp-drive/core/types';
 
 interface Signature {
   Args: {
@@ -25,17 +27,16 @@ export default class IconSelectComponent extends Component<Signature> {
   loadIconCatalogTask = task({ restartable: true }, async (search?: string) => {
     await timeout(300); // debounce
 
-    const query: Record<string, unknown> = {
+    const queryParams: LegacyResourceQuery<Icon> = {
       sort: 'label',
     };
 
     if (search?.length) {
-      query['filter[label]'] = search;
+      queryParams['filter[label]'] = search;
     }
 
-    // @ts-expect-error we're running into strange type errors with the query argument. Not sure how to fix this properly.
-    // TODO: fix the query types
-    const result = await this.store.query<Icon>('icon', query);
+    const result = (await this.store.request(query<Icon>('icon', queryParams)))
+      .content;
 
     return result.slice();
   });

--- a/app/components/image-upload-handler.ts
+++ b/app/components/image-upload-handler.ts
@@ -6,6 +6,7 @@ import Image from 'mow-registry/models/image';
 import type TrafficSignalConcept from 'mow-registry/models/traffic-signal-concept';
 import type Icon from 'mow-registry/models/icon';
 import type RoadSignConcept from 'mow-registry/models/road-sign-concept';
+import { saveRecord } from '@warp-drive/legacy/compat/builders';
 
 /**
  * A helper for uploading images, used in conjunction with `image-input.js`
@@ -37,7 +38,7 @@ export default class ImageUploadHandlerComponent<
       const imageFileData = await this.fileService.upload(this.fileData);
       const imageRecord = this.store.createRecord<Image>('image', {});
       imageRecord.set('file', imageFileData);
-      await imageRecord.save();
+      await this.store.request(saveRecord(imageRecord));
       return imageRecord;
     }
     return null;

--- a/app/components/road-marking-form.ts
+++ b/app/components/road-marking-form.ts
@@ -17,6 +17,7 @@ import {
   validateShapes,
   validateVariables,
 } from 'mow-registry/utils/validate-relations';
+import { saveRecord } from '@warp-drive/legacy/compat/builders';
 
 type Args = {
   roadMarkingConcept: RoadMarkingConcept;
@@ -115,10 +116,10 @@ export default class RoadMarkingFormComponent extends ImageUploadHandlerComponen
         ...(await this.args.roadMarkingConcept.shapes).map(async (shape) => {
           await Promise.all(
             (await shape.dimensions).map(async (dimension) => {
-              await dimension.save();
+              await this.store.request(saveRecord(dimension));
             }),
           );
-          await shape.save();
+          await this.store.request(saveRecord(shape));
         }),
       );
 
@@ -141,7 +142,7 @@ export default class RoadMarkingFormComponent extends ImageUploadHandlerComponen
       savePromises.push(
         ...(await this.args.roadMarkingConcept.variables).map(
           async (variable) => {
-            await variable.save();
+            await this.store.request(saveRecord(variable));
           },
         ),
       );
@@ -151,7 +152,7 @@ export default class RoadMarkingFormComponent extends ImageUploadHandlerComponen
       );
 
       await Promise.all(savePromises);
-      await this.args.roadMarkingConcept.save();
+      await this.store.request(saveRecord(this.args.roadMarkingConcept));
       this.router.transitionTo(
         'road-marking-concepts.road-marking-concept',
         this.args.roadMarkingConcept.id,

--- a/app/components/road-sign-form.gts
+++ b/app/components/road-sign-form.gts
@@ -48,6 +48,7 @@ import {
   validateShapes,
   validateVariables,
 } from 'mow-registry/utils/validate-relations';
+import { saveRecord } from '@warp-drive/legacy/compat/builders';
 
 type Args = {
   roadSignConcept: RoadSignConcept;
@@ -175,10 +176,10 @@ export default class RoadSignFormComponent extends ImageUploadHandlerComponent<A
         ...(await this.args.roadSignConcept.shapes).map(async (shape) => {
           await Promise.all(
             (await shape.dimensions).map(async (dimension) => {
-              await dimension.save();
+              await this.store.request(saveRecord(dimension));
             }),
           );
-          await shape.save();
+          await this.store.request(saveRecord(shape));
         }),
       );
 
@@ -200,7 +201,7 @@ export default class RoadSignFormComponent extends ImageUploadHandlerComponent<A
 
       savePromises.push(
         ...(await this.args.roadSignConcept.variables).map(async (variable) => {
-          await variable.save();
+          await this.store.request(saveRecord(variable));
         }),
       );
 
@@ -209,7 +210,7 @@ export default class RoadSignFormComponent extends ImageUploadHandlerComponent<A
       );
 
       await Promise.all(savePromises);
-      await this.args.roadSignConcept.save();
+      await this.store.request(saveRecord(this.args.roadSignConcept));
       void this.router.transitionTo(
         'road-sign-concepts.road-sign-concept',
         this.args.roadSignConcept.id,

--- a/app/components/traffic-light-form.ts
+++ b/app/components/traffic-light-form.ts
@@ -11,6 +11,7 @@ import type { ModifiableKeysOfType } from 'mow-registry/utils/type-utils';
 import type Variable from 'mow-registry/models/variable';
 import { removeItem } from 'mow-registry/utils/array';
 import { validateVariables } from 'mow-registry/utils/validate-relations';
+import { saveRecord } from '@warp-drive/legacy/compat/builders';
 
 type Args = {
   trafficLightConcept: TrafficLightConcept;
@@ -79,7 +80,7 @@ export default class TrafficLightFormComponent extends ImageUploadHandlerCompone
       await Promise.all(
         (await this.args.trafficLightConcept.variables).map(
           async (variable) => {
-            await variable.save();
+            await this.store.request(saveRecord(variable));
           },
         ),
       );
@@ -87,8 +88,7 @@ export default class TrafficLightFormComponent extends ImageUploadHandlerCompone
       await Promise.all(
         this.variablesToRemove.map((variable) => variable.destroyRecord()),
       );
-
-      await this.args.trafficLightConcept.save();
+      await this.store.request(saveRecord(this.args.trafficLightConcept));
       this.router.transitionTo(
         'traffic-light-concepts.traffic-light-concept',
         this.args.trafficLightConcept.id,

--- a/app/components/traffic-measure/index.ts
+++ b/app/components/traffic-measure/index.ts
@@ -23,6 +23,7 @@ import { removeItem } from 'mow-registry/utils/array';
 import { TrackedArray } from 'tracked-built-ins';
 import validateTrafficMeasureDates from 'mow-registry/utils/validate-traffic-measure-dates';
 import type SkosConcept from 'mow-registry/models/skos-concept';
+import { saveRecord } from '@warp-drive/legacy/compat/builders';
 
 export type InputType = {
   value: string;
@@ -429,9 +430,9 @@ export default class TrafficMeasureIndexComponent extends Component<Args> {
 
     //if new save relationships
     if (this.new) {
-      await this.trafficMeasureConcept.save();
-      await template.save();
-      await this.trafficMeasureConcept.save();
+      await this.store.request(saveRecord(this.trafficMeasureConcept));
+      await this.store.request(saveRecord(template));
+      await this.store.request(saveRecord(this.trafficMeasureConcept));
     }
 
     //1-parse everything again
@@ -439,7 +440,7 @@ export default class TrafficMeasureIndexComponent extends Component<Args> {
 
     //2-update node shape
     this.trafficMeasureConcept.label = this.label;
-    await this.trafficMeasureConcept.save();
+    await this.store.request(saveRecord(this.trafficMeasureConcept));
 
     //3-update roadsigns
     await this.saveRoadsigns.perform(this.trafficMeasureConcept);
@@ -471,12 +472,12 @@ export default class TrafficMeasureIndexComponent extends Component<Args> {
 
     for (const sign of deletedSigns) {
       removeItem(await sign.hasTrafficMeasureConcepts, trafficMeasureConcept);
-      await sign.save();
+      await this.store.request(saveRecord(sign));
     }
 
     for (const sign of addedSigns) {
       (await sign.hasTrafficMeasureConcepts).push(trafficMeasureConcept);
-      await sign.save();
+      await this.store.request(saveRecord(sign));
     }
   });
 
@@ -489,10 +490,10 @@ export default class TrafficMeasureIndexComponent extends Component<Args> {
     //create new ones
     for (const variable of this.variables) {
       (await template.variables).push(variable);
-      await variable.save();
+      await this.store.request(saveRecord(variable));
     }
 
-    await template.save();
+    await this.store.request(saveRecord(template));
   });
 
   willDestroy() {

--- a/app/components/zonality-selector.gts
+++ b/app/components/zonality-selector.gts
@@ -11,6 +11,7 @@ import zonalityLabel from 'mow-registry/helpers/zonality-label';
 import t from 'ember-intl/helpers/t';
 import type TrafficSignalConcept from 'mow-registry/models/traffic-signal-concept';
 import { get } from '@ember/helper';
+import { findRecord } from '@warp-drive/legacy/compat/builders';
 
 type Args = {
   model: TrafficSignalConcept;
@@ -24,10 +25,11 @@ export default class ZonalitySelectorComponent extends Component<Args> {
   zonalities = trackedFunction(this, async () => {
     // Detach from the auto-tracking prelude, to prevent infinite loop/call issues, see https://github.com/universal-ember/reactiveweb/issues/129
     await Promise.resolve();
-    const conceptScheme = await this.store.findRecord<ConceptScheme>(
-      'concept-scheme',
-      ZON_CONCEPT_SCHEME_ID,
-    );
+    const conceptScheme = await this.store
+      .request(
+        findRecord<ConceptScheme>('concept-scheme', ZON_CONCEPT_SCHEME_ID),
+      )
+      .then((res) => res.content);
     return conceptScheme.concepts;
   });
 

--- a/app/controllers/codelists-management/index.ts
+++ b/app/controllers/codelists-management/index.ts
@@ -7,6 +7,7 @@ import { trackedFunction } from 'reactiveweb/function';
 import Store from 'mow-registry/services/store';
 import type CodeList from 'mow-registry/models/code-list';
 import type { LegacyResourceQuery } from '@warp-drive/core/types';
+import { query } from '@warp-drive/legacy/compat/builders';
 
 export default class CodelistsManagementIndexController extends Controller {
   queryParams = ['page', 'size', 'label', 'sort'];
@@ -40,7 +41,7 @@ export default class CodelistsManagementIndexController extends Controller {
   }
 
   codelists = trackedFunction(this, async () => {
-    const query: LegacyResourceQuery<CodeList> = {
+    const queryParams: LegacyResourceQuery<CodeList> = {
       include: ['type'],
       sort: this.sort,
       page: {
@@ -50,13 +51,14 @@ export default class CodelistsManagementIndexController extends Controller {
     };
 
     if (this.label) {
-      query['filter'] = {
+      queryParams['filter'] = {
         label: this.label,
       };
     }
     // Detach from the auto-tracking prelude, to prevent infinite loop/call issues, see https://github.com/universal-ember/reactiveweb/issues/129
     await Promise.resolve();
 
-    return await this.store.query<CodeList>('code-list', query);
+    return (await this.store.request(query<CodeList>('code-list', queryParams)))
+      .content;
   });
 }

--- a/app/controllers/icon-catalog/index.ts
+++ b/app/controllers/icon-catalog/index.ts
@@ -9,6 +9,7 @@ import { trackedFunction } from 'reactiveweb/function';
 import Store from 'mow-registry/services/store';
 import type Icon from 'mow-registry/models/icon';
 import type { LegacyResourceQuery } from '@warp-drive/core/types';
+import { query } from '@warp-drive/legacy/compat/builders';
 
 export default class IconCatalogIndexController extends Controller {
   queryParams = ['page', 'size', 'label', 'sort'];
@@ -41,7 +42,7 @@ export default class IconCatalogIndexController extends Controller {
     this.page = 0;
   }
   icons = trackedFunction(this, async () => {
-    const query: LegacyResourceQuery<Icon> = {
+    const queryParams: LegacyResourceQuery<Icon> = {
       // TODO: The types expect an array, but the adapter doesn't convert that to the expected json:api include format
       // More info: https://github.com/emberjs/data/pull/9507#issuecomment-2219588690
       include: ['image.file', 'inScheme'],
@@ -53,13 +54,13 @@ export default class IconCatalogIndexController extends Controller {
     };
 
     if (this.label) {
-      query['filter'] = {
+      queryParams['filter'] = {
         label: this.label,
       };
     }
     // Detach from the auto-tracking prelude, to prevent infinite loop/call issues, see https://github.com/universal-ember/reactiveweb/issues/129
     await Promise.resolve();
 
-    return await this.store.query<Icon>('icon', query);
+    return (await this.store.request(query<Icon>('icon', queryParams))).content;
   });
 }

--- a/app/controllers/road-marking-concepts/road-marking-concept/instructions/index.ts
+++ b/app/controllers/road-marking-concepts/road-marking-concept/instructions/index.ts
@@ -6,8 +6,11 @@ import { removeItem } from 'mow-registry/utils/array';
 import type { ModelFrom } from 'mow-registry/utils/type-utils';
 import { service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
+import type Store from 'mow-registry/services/store';
+import { saveRecord } from '@warp-drive/legacy/compat/builders';
 
 export default class RoadMarkingConceptsRoadMarkingConceptInstructionsIndexController extends Controller {
+  @service declare store: Store;
   @service
   declare intl: IntlService;
   declare model: ModelFrom<Route>;
@@ -18,6 +21,6 @@ export default class RoadMarkingConceptsRoadMarkingConceptInstructionsIndexContr
     removeItem(templates, template);
 
     await template.destroyRecord();
-    await this.model.roadMarkingConcept.save();
+    await this.store.request(saveRecord(this.model.roadMarkingConcept));
   });
 }

--- a/app/controllers/road-marking-concepts/road-marking-concept/related.ts
+++ b/app/controllers/road-marking-concepts/road-marking-concept/related.ts
@@ -2,16 +2,19 @@ import Controller from '@ember/controller';
 import type RouterService from '@ember/routing/router-service';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import { saveRecord } from '@warp-drive/legacy/compat/builders';
 import { task } from 'ember-concurrency';
 import type RoadMarkingConcept from 'mow-registry/models/road-marking-concept';
 import type RoadSignCategory from 'mow-registry/models/road-sign-category';
 import type RoadSignConcept from 'mow-registry/models/road-sign-concept';
 import type TrafficLightConcept from 'mow-registry/models/traffic-light-concept';
 import type Route from 'mow-registry/routes/road-marking-concepts/road-marking-concept/related';
+import type Store from 'mow-registry/services/store';
 import { removeItem } from 'mow-registry/utils/array';
 import type { ModelFrom } from 'mow-registry/utils/type-utils';
 
 export default class RoadMarkingConceptsRoadMarkingConceptRelatedController extends Controller {
+  @service declare store: Store;
   @service declare router: RouterService;
   declare model: ModelFrom<Route>;
 
@@ -68,7 +71,7 @@ export default class RoadMarkingConceptsRoadMarkingConceptRelatedController exte
     relatedToRoadMarkingConcepts.push(relatedRoadMarking);
     relatedRoadMarkingConcepts.push(relatedRoadMarking);
 
-    await this.model.roadMarkingConcept.save();
+    await this.store.request(saveRecord(this.model.roadMarkingConcept));
   });
 
   removeRelatedRoadMarking = task(
@@ -84,8 +87,8 @@ export default class RoadMarkingConceptsRoadMarkingConceptRelatedController exte
       removeItem(relatedFromRoadMarkingConcepts, relatedRoadMarking);
       removeItem(relatedRoadMarkingConcepts, relatedRoadMarking);
 
-      await relatedRoadMarking.save();
-      await this.model.roadMarkingConcept.save();
+      await this.store.request(saveRecord(relatedRoadMarking));
+      await this.store.request(saveRecord(this.model.roadMarkingConcept));
     },
   );
 
@@ -97,7 +100,7 @@ export default class RoadMarkingConceptsRoadMarkingConceptRelatedController exte
     if (this.classificationRoadSigns) {
       removeItem(this.classificationRoadSigns, relatedRoadSign);
     }
-    await this.model.roadMarkingConcept.save();
+    await this.store.request(saveRecord(this.model.roadMarkingConcept));
   });
 
   removeRelatedRoadSign = task(async (relatedRoadSign: RoadSignConcept) => {
@@ -110,7 +113,7 @@ export default class RoadMarkingConceptsRoadMarkingConceptRelatedController exte
       this.classificationRoadSigns.push(relatedRoadSign);
     }
 
-    await this.model.roadMarkingConcept.save();
+    await this.store.request(saveRecord(this.model.roadMarkingConcept));
   });
 
   handleCategorySelection = task(
@@ -133,7 +136,7 @@ export default class RoadMarkingConceptsRoadMarkingConceptRelatedController exte
         await this.model.roadMarkingConcept.relatedTrafficLightConcepts;
 
       relatedTrafficLights.push(relatedTrafficLight);
-      await this.model.roadMarkingConcept.save();
+      await this.store.request(saveRecord(this.model.roadMarkingConcept));
     },
   );
 
@@ -143,8 +146,7 @@ export default class RoadMarkingConceptsRoadMarkingConceptRelatedController exte
         await this.model.roadMarkingConcept.relatedTrafficLightConcepts;
 
       removeItem(relatedTrafficLights, relatedTrafficLight);
-
-      await this.model.roadMarkingConcept.save();
+      await this.store.request(saveRecord(this.model.roadMarkingConcept));
     },
   );
 

--- a/app/controllers/road-sign-concepts/road-sign-concept/instructions/index.ts
+++ b/app/controllers/road-sign-concepts/road-sign-concept/instructions/index.ts
@@ -6,10 +6,13 @@ import { removeItem } from 'mow-registry/utils/array';
 import type { ModelFrom } from 'mow-registry/utils/type-utils';
 import { service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
+import type Store from 'mow-registry/services/store';
+import { saveRecord } from '@warp-drive/legacy/compat/builders';
 
 export default class RoadSignConceptsRoadSignConceptInstructionsIndexController extends Controller {
   @service
   declare intl: IntlService;
+  @service declare store: Store;
   declare model: ModelFrom<RoadsignConceptsEditRoute>;
 
   removeTemplate = task(async (template: Template) => {
@@ -18,6 +21,6 @@ export default class RoadSignConceptsRoadSignConceptInstructionsIndexController 
     removeItem(templates, template);
 
     await template.destroyRecord();
-    await this.model.roadSignConcept.save();
+    await this.store.request(saveRecord(this.model.roadSignConcept));
   });
 }

--- a/app/controllers/road-sign-concepts/road-sign-concept/main-signs.ts
+++ b/app/controllers/road-sign-concepts/road-sign-concept/main-signs.ts
@@ -1,14 +1,19 @@
 import Controller from '@ember/controller';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import { saveRecord } from '@warp-drive/legacy/compat/builders';
 import { task } from 'ember-concurrency';
 import RoadSignCategory from 'mow-registry/models/road-sign-category';
 import type RoadSignConcept from 'mow-registry/models/road-sign-concept';
 import MainSignsRoute from 'mow-registry/routes/road-sign-concepts/road-sign-concept/main-signs';
+import type Store from 'mow-registry/services/store';
 import { removeItem } from 'mow-registry/utils/array';
 import type { ModelFrom } from 'mow-registry/utils/type-utils';
 import { TrackedArray } from 'tracked-built-ins';
 
 export default class RoadSignConceptsRoadSignConceptMainSignsController extends Controller {
+  @service declare store: Store;
+
   declare model: ModelFrom<MainSignsRoute>;
   @tracked isAddingMainSigns = false;
   @tracked mainSignCodeFilter = '';
@@ -26,7 +31,7 @@ export default class RoadSignConceptsRoadSignConceptMainSignsController extends 
     if (this.classificationRoadSigns) {
       removeItem(this.classificationRoadSigns, mainSign);
     }
-    await this.model.roadSignConcept.save();
+    await this.store.request(saveRecord(this.model.roadSignConcept));
   });
 
   removeMainSign = task(async (mainSign) => {
@@ -37,8 +42,7 @@ export default class RoadSignConceptsRoadSignConceptMainSignsController extends 
     if (this.classificationRoadSigns) {
       this.classificationRoadSigns.push(mainSign);
     }
-
-    await this.model.roadSignConcept.save();
+    await this.store.request(saveRecord(this.model.roadSignConcept));
   });
 
   handleCategorySelection = task(async (classification: RoadSignCategory) => {

--- a/app/controllers/road-sign-concepts/road-sign-concept/related.ts
+++ b/app/controllers/road-sign-concepts/road-sign-concept/related.ts
@@ -1,16 +1,21 @@
 import Controller from '@ember/controller';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import { saveRecord } from '@warp-drive/legacy/compat/builders';
 import { task } from 'ember-concurrency';
 import RoadMarkingConcept from 'mow-registry/models/road-marking-concept';
 import RoadSignCategory from 'mow-registry/models/road-sign-category';
 import RoadSignConcept from 'mow-registry/models/road-sign-concept';
 import TrafficLightConcept from 'mow-registry/models/traffic-light-concept';
 import RelatedRoute from 'mow-registry/routes/road-sign-concepts/road-sign-concept/related';
+import type Store from 'mow-registry/services/store';
 import { removeItem } from 'mow-registry/utils/array';
 import type { ModelFrom } from 'mow-registry/utils/type-utils';
 import { TrackedArray } from 'tracked-built-ins';
 
 export default class RoadSignConceptsRoadSignConceptRelatedController extends Controller {
+  @service declare store: Store;
+
   declare model: ModelFrom<RelatedRoute>;
   @tracked isAddingRelatedRoadSigns = false;
   @tracked isAddingRelatedRoadMarkings = false;
@@ -72,8 +77,7 @@ export default class RoadSignConceptsRoadSignConceptRelatedController extends Co
 
     relatedToRoadSignConcepts.push(relatedRoadSign);
     relatedRoadSignConcepts.push(relatedRoadSign);
-
-    await this.model.roadSignConcept.save();
+    await this.store.request(saveRecord(this.model.roadSignConcept));
   });
 
   removeRelatedRoadSign = task(async (relatedRoadSign: RoadSignConcept) => {
@@ -88,8 +92,8 @@ export default class RoadSignConceptsRoadSignConceptRelatedController extends Co
     removeItem(relatedFromRoadSignConcepts, relatedRoadSign);
     removeItem(relatedRoadSignConcepts, relatedRoadSign);
 
-    await relatedRoadSign.save();
-    await this.model.roadSignConcept.save();
+    await this.store.request(saveRecord(relatedRoadSign));
+    await this.store.request(saveRecord(this.model.roadSignConcept));
   });
 
   addRelatedRoadMarking = task(
@@ -98,7 +102,7 @@ export default class RoadSignConceptsRoadSignConceptRelatedController extends Co
         await this.model.roadSignConcept.relatedRoadMarkingConcepts;
 
       relatedRoadMarkings.push(relatedRoadMarking);
-      await relatedRoadMarking.save();
+      await this.store.request(saveRecord(relatedRoadMarking));
     },
   );
 
@@ -107,7 +111,8 @@ export default class RoadSignConceptsRoadSignConceptRelatedController extends Co
       const relatedRoadMarkings =
         await this.model.roadSignConcept.relatedRoadMarkingConcepts;
       removeItem(relatedRoadMarkings, relatedRoadMarking);
-      await relatedRoadMarking.save();
+
+      await this.store.request(saveRecord(relatedRoadMarking));
     },
   );
 
@@ -117,7 +122,8 @@ export default class RoadSignConceptsRoadSignConceptRelatedController extends Co
         await this.model.roadSignConcept.relatedTrafficLightConcepts;
 
       relatedTrafficLights.push(relatedTrafficLight);
-      await this.model.roadSignConcept.save();
+
+      await this.store.request(saveRecord(this.model.roadSignConcept));
     },
   );
 
@@ -127,7 +133,7 @@ export default class RoadSignConceptsRoadSignConceptRelatedController extends Co
 
     removeItem(relatedTrafficLights, relatedTrafficLight);
 
-    await this.model.roadSignConcept.save();
+    await this.store.request(saveRecord(this.model.roadSignConcept));
   });
 
   handleCategorySelection = task(

--- a/app/controllers/road-sign-concepts/road-sign-concept/sub-signs.ts
+++ b/app/controllers/road-sign-concepts/road-sign-concept/sub-signs.ts
@@ -1,12 +1,17 @@
 import Controller from '@ember/controller';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import { saveRecord } from '@warp-drive/legacy/compat/builders';
 import { task } from 'ember-concurrency';
 import RoadSignConcept from 'mow-registry/models/road-sign-concept';
 import type SubSignsRoute from 'mow-registry/routes/road-sign-concepts/road-sign-concept/sub-signs';
+import type Store from 'mow-registry/services/store';
 import { removeItem } from 'mow-registry/utils/array';
 import type { ModelFrom } from 'mow-registry/utils/type-utils';
 
 export default class RoadSignConceptsRoadSignConceptSubSignsController extends Controller {
+  @service declare store: Store;
+
   declare model: ModelFrom<SubSignsRoute>;
   @tracked isAddingSubSigns = false;
   @tracked subSignCodeFilter = '';
@@ -31,14 +36,14 @@ export default class RoadSignConceptsRoadSignConceptSubSignsController extends C
     const subSigns = await this.model.roadSignConcept.subSigns;
     subSigns.push(subSign);
     removeItem(this.model.allSubSigns, subSign);
-    await this.model.roadSignConcept.save();
+    await this.store.request(saveRecord(this.model.roadSignConcept));
   });
 
   removeSubSign = task(async (subSign) => {
     const subSigns = await this.model.roadSignConcept.subSigns;
     removeItem(subSigns, subSign);
     this.model.allSubSigns.push(subSign);
-    await this.model.roadSignConcept.save();
+    await this.store.request(saveRecord(this.model.roadSignConcept));
   });
 
   toggleAddSubSigns = () => {

--- a/app/controllers/traffic-light-concepts/traffic-light-concept/instructions/index.ts
+++ b/app/controllers/traffic-light-concepts/traffic-light-concept/instructions/index.ts
@@ -6,10 +6,13 @@ import { removeItem } from 'mow-registry/utils/array';
 import type { ModelFrom } from 'mow-registry/utils/type-utils';
 import { service } from '@ember/service';
 import IntlService from 'ember-intl/services/intl';
+import type Store from 'mow-registry/services/store';
+import { saveRecord } from '@warp-drive/legacy/compat/builders';
 
 export default class TrafficLightConceptsTrafficLightConceptInstructionsIndexController extends Controller {
   @service
   declare intl: IntlService;
+  @service declare store: Store;
   declare model: ModelFrom<Route>;
 
   removeTemplate = task(async (template: Template) => {
@@ -18,6 +21,6 @@ export default class TrafficLightConceptsTrafficLightConceptInstructionsIndexCon
     removeItem(templates, template);
 
     await template.destroyRecord();
-    await this.model.trafficLightConcept.save();
+    await this.store.request(saveRecord(this.model.trafficLightConcept));
   });
 }

--- a/app/controllers/traffic-light-concepts/traffic-light-concept/related.ts
+++ b/app/controllers/traffic-light-concepts/traffic-light-concept/related.ts
@@ -9,9 +9,12 @@ import type TrafficLightConcept from 'mow-registry/models/traffic-light-concept'
 import type RoadSignCategory from 'mow-registry/models/road-sign-category';
 import type TrafficlightConceptRelatedRoute from 'mow-registry/routes/traffic-light-concepts/traffic-light-concept/related';
 import { removeItem } from 'mow-registry/utils/array';
+import type Store from 'mow-registry/services/store';
+import { saveRecord } from '@warp-drive/legacy/compat/builders';
 
 export default class TrafficLightConceptsTrafficLightConceptRelatedController extends Controller {
   @service declare router: RouterService;
+  @service declare store: Store;
   declare model: ModelFrom<TrafficlightConceptRelatedRoute>;
 
   @tracked isAddingRelatedRoadSigns = false;
@@ -74,7 +77,7 @@ export default class TrafficLightConceptsTrafficLightConceptRelatedController ex
     relatedToTrafficLightConcepts.push(relatedTrafficLight);
     relatedTrafficLightConcepts.push(relatedTrafficLight);
 
-    await this.model.trafficLightConcept.save();
+    await this.store.request(saveRecord(this.model.trafficLightConcept));
   });
 
   addRelatedRoadSign = task(async (relatedRoadSign: RoadSignConcept) => {
@@ -85,7 +88,7 @@ export default class TrafficLightConceptsTrafficLightConceptRelatedController ex
     if (this.classificationRoadSigns) {
       removeItem(this.classificationRoadSigns, relatedRoadSign);
     }
-    await this.model.trafficLightConcept.save();
+    await this.store.request(saveRecord(this.model.trafficLightConcept));
   });
 
   removeRelatedRoadSign = task(async (relatedRoadSign) => {
@@ -98,7 +101,7 @@ export default class TrafficLightConceptsTrafficLightConceptRelatedController ex
       this.classificationRoadSigns.push(relatedRoadSign);
     }
 
-    await this.model.trafficLightConcept.save();
+    await this.store.request(saveRecord(this.model.trafficLightConcept));
   });
 
   addRelatedRoadMarking = task(async (relatedRoadMarking) => {
@@ -106,7 +109,7 @@ export default class TrafficLightConceptsTrafficLightConceptRelatedController ex
       await this.model.trafficLightConcept.relatedRoadMarkingConcepts;
 
     relatedRoadMarkings.push(relatedRoadMarking);
-    await this.model.trafficLightConcept.save();
+    await this.store.request(saveRecord(this.model.trafficLightConcept));
   });
 
   removeRelatedRoadMarking = task(async (relatedRoadMarking) => {
@@ -115,7 +118,7 @@ export default class TrafficLightConceptsTrafficLightConceptRelatedController ex
 
     removeItem(relatedRoadMarkings, relatedRoadMarking);
 
-    await this.model.trafficLightConcept.save();
+    await this.store.request(saveRecord(this.model.trafficLightConcept));
   });
 
   handleCategorySelection = task(async (classification: RoadSignCategory) => {
@@ -143,8 +146,8 @@ export default class TrafficLightConceptsTrafficLightConceptRelatedController ex
       removeItem(relatedFromTrafficLightConcepts, relatedTrafficLight);
       removeItem(relatedTrafficLightConcepts, relatedTrafficLight);
 
-      await relatedTrafficLight.save();
-      await this.model.trafficLightConcept.save();
+      await this.store.request(saveRecord(relatedTrafficLight));
+      await this.store.request(saveRecord(this.model.trafficLightConcept));
     },
   );
 

--- a/app/controllers/traffic-measure-concepts/details.ts
+++ b/app/controllers/traffic-measure-concepts/details.ts
@@ -6,6 +6,7 @@ import Store from 'mow-registry/services/store';
 import type NodeShape from 'mow-registry/models/node-shape';
 import type TrafficMeasureConceptsDetailsRoute from 'mow-registry/routes/traffic-measure-concepts/details';
 import type { ModelFrom } from 'mow-registry/utils/type-utils';
+import { query } from '@warp-drive/legacy/compat/builders';
 
 export default class TrafficMeasureConceptsDetailsController extends Controller {
   @service declare router: RouterService;
@@ -13,9 +14,13 @@ export default class TrafficMeasureConceptsDetailsController extends Controller 
   declare model: ModelFrom<TrafficMeasureConceptsDetailsRoute>;
 
   delete = task(async () => {
-    const nodeShapes = await this.store.query<NodeShape>('node-shape', {
-      'filter[targetHasConcept][id]': this.model.trafficMeasureConcept.id,
-    });
+    const nodeShapes = (
+      await this.store.request(
+        query<NodeShape>('node-shape', {
+          'filter[targetHasConcept][id]': this.model.trafficMeasureConcept.id,
+        }),
+      )
+    ).content;
 
     const nodeShape = nodeShapes[0];
     if (nodeShape) {

--- a/app/controllers/traffic-measure-concepts/index.ts
+++ b/app/controllers/traffic-measure-concepts/index.ts
@@ -8,9 +8,11 @@ import type IntlService from 'ember-intl/services/intl';
 import fetchManualData from 'mow-registry/utils/fetch-manual-data';
 import generateMeta from 'mow-registry/utils/generate-meta';
 import Store from 'mow-registry/services/store';
-import type TrafficMeasureConcept from 'mow-registry/models/traffic-measure-concept';
+import TrafficMeasureConcept from 'mow-registry/models/traffic-measure-concept';
 import { trackedFunction } from 'reactiveweb/function';
 import type { LegacyResourceQuery } from '@warp-drive/core/types';
+import { query } from '@warp-drive/legacy/compat/builders';
+import type { Collection } from 'mow-registry/utils/type-utils';
 
 export default class TrafficMeasureConceptsIndexController extends Controller {
   queryParams = [
@@ -85,7 +87,7 @@ export default class TrafficMeasureConceptsIndexController extends Controller {
   );
 
   trafficMeasures = trackedFunction(this, async () => {
-    const query: LegacyResourceQuery<TrafficMeasureConcept> = {
+    const queryParams: LegacyResourceQuery<TrafficMeasureConcept> = {
       sort: this.sort,
       filter: {},
     };
@@ -103,19 +105,23 @@ export default class TrafficMeasureConceptsIndexController extends Controller {
         validityEndDate: this.validityEndDate,
       },
     );
-    query['filter'] = {
+    queryParams['filter'] = {
       id: trafficMeasureConceptUris.join(','),
     };
     // Detach from the auto-tracking prelude, to prevent infinite loop/call issues, see https://github.com/universal-ember/reactiveweb/issues/129
     await Promise.resolve();
-    const trafficMeasures = trafficMeasureConceptUris.length
-      ? await this.store.query<TrafficMeasureConcept>(
-          'traffic-measure-concept',
-          query,
-        )
-      : ([] as TrafficMeasureConcept[] as Awaited<
-          ReturnType<typeof this.store.query<TrafficMeasureConcept>>
-        >);
+    const trafficMeasures = (
+      trafficMeasureConceptUris.length
+        ? (
+            await this.store.request(
+              query<TrafficMeasureConcept>(
+                'traffic-measure-concept',
+                queryParams,
+              ),
+            )
+          ).content
+        : []
+    ) as Collection<TrafficMeasureConcept>;
     trafficMeasures.meta = generateMeta(
       { page: this.page, size: this.size },
       count,

--- a/app/routes/codelists-management/codelist.ts
+++ b/app/routes/codelists-management/codelist.ts
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 import CodelistController from 'mow-registry/controllers/codelists-management/codelist';
 import type CodeList from 'mow-registry/models/code-list';
 import { hash } from 'rsvp';
+import { findRecord } from '@warp-drive/legacy/compat/builders';
 
 type Params = {
   id: string;
@@ -13,11 +14,13 @@ export default class CodelistsManagementCodelistRoute extends Route {
 
   async model(params: Params) {
     const model = await hash({
-      codelist: this.store.findRecord<CodeList>('code-list', params.id, {
-        // @ts-expect-error: The types expect an array, but the adapter doesn't convert that to the expected json:api include format
-        // More info: https://github.com/emberjs/data/pull/9507#issuecomment-2219588690
-        include: ['type', 'concepts'].join(),
-      }),
+      codelist: this.store
+        .request(
+          findRecord<CodeList>('code-list', params.id, {
+            include: ['type', 'concepts'].join(),
+          }),
+        )
+        .then((res) => res.content),
     });
 
     return model;

--- a/app/routes/codelists-management/edit.ts
+++ b/app/routes/codelists-management/edit.ts
@@ -2,6 +2,7 @@ import Store from 'mow-registry/services/store';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import type CodeList from 'mow-registry/models/code-list';
+import { findRecord } from '@warp-drive/legacy/compat/builders';
 
 type Params = {
   id: string;
@@ -10,10 +11,9 @@ export default class CodelistsManagementEditRoute extends Route {
   @service declare store: Store;
 
   async model(params: Params) {
-    const codelist = await this.store.findRecord<CodeList>(
-      'code-list',
-      params.id,
-    );
+    const codelist = await this.store
+      .request(findRecord<CodeList>('code-list', params.id))
+      .then((res) => res.content);
     const concepts = await codelist.concepts;
 
     return {

--- a/app/routes/icon-catalog/edit.ts
+++ b/app/routes/icon-catalog/edit.ts
@@ -3,6 +3,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import IconCatalogEditController from 'mow-registry/controllers/icon-catalog/edit';
 import type Icon from 'mow-registry/models/icon';
+import { findRecord } from '@warp-drive/legacy/compat/builders';
 
 type Params = {
   id: string;
@@ -12,7 +13,9 @@ export default class IconCatalogEditRoute extends Route {
 
   async model(params: Params) {
     return {
-      icon: await this.store.findRecord<Icon>('icon', params.id),
+      icon: await this.store
+        .request(findRecord<Icon>('icon', params.id))
+        .then((res) => res.content),
     };
   }
 

--- a/app/routes/icon-catalog/icon.ts
+++ b/app/routes/icon-catalog/icon.ts
@@ -3,6 +3,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import IconCatalogIconController from 'mow-registry/controllers/icon-catalog/icon';
 import type Icon from 'mow-registry/models/icon';
+import { findRecord } from '@warp-drive/legacy/compat/builders';
 
 type Params = {
   id: string;
@@ -13,7 +14,9 @@ export default class IconCatalogIconRoute extends Route {
 
   async model(params: Params) {
     return {
-      icon: await this.store.findRecord<Icon>('icon', params.id),
+      icon: await this.store
+        .request(findRecord<Icon>('icon', params.id))
+        .then((res) => res.content),
     };
   }
 

--- a/app/routes/mock-login.ts
+++ b/app/routes/mock-login.ts
@@ -3,7 +3,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import type Account from 'mow-registry/models/account';
 import SessionService from 'mow-registry/services/session';
-
+import { query } from '@warp-drive/legacy/compat/builders';
 type Params = {
   page: number;
 };
@@ -23,14 +23,16 @@ export default class MockLoginRoute extends Route {
     this.session.prohibitAuthentication('index');
   }
   async model(params: Params) {
-    const filter = { provider: 'https://github.com/lblod/mock-login-service' };
-    const accounts = await this.store.query<Account>('account', {
-      // @ts-expect-error we're running into strange type errors with the query argument. Not sure how to fix this properly.
-      // TODO: fix the query types
-      include: 'user.groups',
-      filter: filter,
-      page: { size: 10, number: params.page },
-    });
+    const accounts = await this.store
+      .request(
+        query<Account>('account', {
+          include: ['user.groups'],
+          'filter[provider]': 'https://github.com/lblod/mock-login-service',
+          'page[size]': 10,
+          'page[number]': params.page,
+        }),
+      )
+      .then((res) => res.content);
     const promises = accounts.map(async (account) => {
       const user = await account.user;
 

--- a/app/routes/road-marking-concepts/edit.ts
+++ b/app/routes/road-marking-concepts/edit.ts
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 import RoadmarkingConceptsEditController from 'mow-registry/controllers/road-marking-concepts/edit';
 import type RoadMarkingConcept from 'mow-registry/models/road-marking-concept';
 import { hash } from 'rsvp';
+import { findRecord } from '@warp-drive/legacy/compat/builders';
 
 type Params = {
   id: string;
@@ -14,23 +15,23 @@ export default class RoadmarkingConceptsEditRoute extends Route {
 
   model(params: Params) {
     return hash({
-      roadMarkingConcept: this.store.findRecord<RoadMarkingConcept>(
-        'road-marking-concept',
-        params.id,
-        {
-          include: [
-            'shapes.dimensions.kind',
-            'shapes.dimensions.unit',
-            'shapes.classification',
-            'defaultShape.dimensions',
-            'defaultShape.classification',
-            'image.file',
-            'variables',
-            'zonality.inScheme.concepts',
-            'inScheme.concepts',
-          ],
-        },
-      ),
+      roadMarkingConcept: this.store
+        .request(
+          findRecord<RoadMarkingConcept>('road-marking-concept', params.id, {
+            include: [
+              'shapes.dimensions.kind',
+              'shapes.dimensions.unit',
+              'shapes.classification',
+              'defaultShape.dimensions',
+              'defaultShape.classification',
+              'image.file',
+              'variables',
+              'zonality.inScheme.concepts',
+              'inScheme.concepts',
+            ],
+          }),
+        )
+        .then((res) => res.content),
     });
   }
   resetController(controller: RoadmarkingConceptsEditController) {

--- a/app/routes/road-marking-concepts/new.ts
+++ b/app/routes/road-marking-concepts/new.ts
@@ -5,15 +5,15 @@ import RoadMarkingConcept from 'mow-registry/models/road-marking-concept';
 import type SkosConcept from 'mow-registry/models/skos-concept';
 import { ZON_NON_ZONAL_ID } from 'mow-registry/utils/constants';
 import { hash } from 'rsvp';
+import { findRecord } from '@warp-drive/legacy/compat/builders';
 
 export default class RoadmarkingConceptsNewRoute extends Route {
   @service declare store: Store;
 
   async model() {
-    const nonZonalConcept = await this.store.findRecord<SkosConcept>(
-      'skos-concept',
-      ZON_NON_ZONAL_ID,
-    );
+    const nonZonalConcept = await this.store
+      .request(findRecord<SkosConcept>('skos-concept', ZON_NON_ZONAL_ID))
+      .then((res) => res.content);
     return hash({
       newRoadMarkingConcept: this.store.createRecord<RoadMarkingConcept>(
         'road-marking-concept',

--- a/app/routes/road-marking-concepts/road-marking-concept.ts
+++ b/app/routes/road-marking-concepts/road-marking-concept.ts
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import Store from 'mow-registry/services/store';
 import type RoadMarkingConcept from 'mow-registry/models/road-marking-concept';
+import { findRecord } from '@warp-drive/legacy/compat/builders';
 
 type Params = {
   id: string;
@@ -12,28 +13,28 @@ export default class RoadmarkingConcept extends Route {
 
   async model(params: Params) {
     return {
-      roadMarkingConcept: await this.store.findRecord<RoadMarkingConcept>(
-        'road-marking-concept',
-        params.id,
-        {
-          include: [
-            'shapes.dimensions.kind',
-            'shapes.dimensions.unit',
-            'shapes.classification',
-            'defaultShape.dimensions',
-            'defaultShape.classification',
-            'image.file',
-            'variables',
-            'zonality.inScheme.concepts',
-            'inScheme.concepts',
-            'relatedRoadSignConcepts',
-            'relatedToRoadMarkingConcepts',
-            'relatedFromRoadMarkingConcepts',
-            'relatedTrafficLightConcepts',
-            'hasInstructions',
-          ],
-        },
-      ),
+      roadMarkingConcept: await this.store
+        .request(
+          findRecord<RoadMarkingConcept>('road-marking-concept', params.id, {
+            include: [
+              'shapes.dimensions.kind',
+              'shapes.dimensions.unit',
+              'shapes.classification',
+              'defaultShape.dimensions',
+              'defaultShape.classification',
+              'image.file',
+              'variables',
+              'zonality.inScheme.concepts',
+              'inScheme.concepts',
+              'relatedRoadSignConcepts',
+              'relatedToRoadMarkingConcepts',
+              'relatedFromRoadMarkingConcepts',
+              'relatedTrafficLightConcepts',
+              'hasInstructions',
+            ],
+          }),
+        )
+        .then((res) => res.content),
     };
   }
 }

--- a/app/routes/road-marking-concepts/road-marking-concept/instructions/edit.ts
+++ b/app/routes/road-marking-concepts/road-marking-concept/instructions/edit.ts
@@ -4,6 +4,7 @@ import type Template from 'mow-registry/models/template';
 import type { ModelFrom } from 'mow-registry/utils/type-utils';
 import Store from 'mow-registry/services/store';
 import type AncesterRoute from 'mow-registry/routes/road-marking-concepts/road-marking-concept';
+import { findRecord } from '@warp-drive/legacy/compat/builders';
 
 type Params = {
   instructionId: string;
@@ -22,13 +23,13 @@ export default class RoadMarkingConceptsRoadMarkingConceptInstructionsEditRoute 
         roadMarkingConcept,
       };
     } else {
-      const template = await this.store.findRecord<Template>(
-        'template',
-        params.instructionId,
-        {
-          include: ['variables'],
-        },
-      );
+      const template = await this.store
+        .request(
+          findRecord<Template>('template', params.instructionId, {
+            include: ['variables'],
+          }),
+        )
+        .then((res) => res.content);
       return {
         template,
         roadMarkingConcept,

--- a/app/routes/road-marking-concepts/road-marking-concept/related.ts
+++ b/app/routes/road-marking-concepts/road-marking-concept/related.ts
@@ -9,6 +9,7 @@ import type RoadMarkingConceptRoute from 'mow-registry/routes/road-marking-conce
 import type { ModelFrom } from 'mow-registry/utils/type-utils';
 import { hash } from 'rsvp';
 import { TrackedArray } from 'tracked-built-ins';
+import { query } from '@warp-drive/legacy/compat/builders';
 
 export default class RoadMarkingConceptsRoadMarkingConceptRelatedRoute extends Route {
   @service declare store: Store;
@@ -21,24 +22,28 @@ export default class RoadMarkingConceptsRoadMarkingConceptRelatedRoute extends R
     const model = await hash({
       roadMarkingConcept,
       allRoadMarkings: this.store
-        .query<RoadMarkingConcept>('road-marking-concept', {
-          page: {
-            size: 10000,
-          },
-        })
+        .request(
+          query<RoadMarkingConcept>('road-marking-concept', {
+            page: {
+              size: 10000,
+            },
+          }),
+        )
+        .then((res) => res.content)
         .then((allRoadMarkings) => {
           return allRoadMarkings.filter(
             (roadMarking) => roadMarking.id !== roadMarkingConcept.id,
           );
         }),
-      allTrafficLights: this.store.query<TrafficLightConcept>(
-        'traffic-light-concept',
-        {
-          page: {
-            size: 10000,
-          },
-        },
-      ),
+      allTrafficLights: this.store
+        .request(
+          query<TrafficLightConcept>('traffic-light-concept', {
+            page: {
+              size: 10000,
+            },
+          }),
+        )
+        .then((res) => res.content),
       classifications: this.store
         .findAll<RoadSignCategory>('road-sign-category')
         .then((classification) => {

--- a/app/routes/road-sign-concepts/edit.ts
+++ b/app/routes/road-sign-concepts/edit.ts
@@ -5,6 +5,7 @@ import RoadsignConceptsEditController from 'mow-registry/controllers/road-sign-c
 import type RoadSignCategory from 'mow-registry/models/road-sign-category';
 import type RoadSignConcept from 'mow-registry/models/road-sign-concept';
 import { hash } from 'rsvp';
+import { findAll, findRecord } from '@warp-drive/legacy/compat/builders';
 
 type Params = {
   id: string;
@@ -14,26 +15,27 @@ export default class RoadsignConceptsEditRoute extends Route {
 
   async model(params: Params) {
     return hash({
-      roadSignConcept: this.store.findRecord<RoadSignConcept>(
-        'road-sign-concept',
-        params.id,
-        {
-          include: [
-            'shapes.dimensions.kind',
-            'shapes.dimensions.unit',
-            'shapes.classification',
-            'defaultShape.dimensions',
-            'defaultShape.classification',
-            'image.file',
-            'variables',
-            'classifications',
-            'zonality.inScheme.concepts',
-            'inScheme.concepts',
-          ],
-        },
-      ),
-      classifications:
-        this.store.findAll<RoadSignCategory>('road-sign-category'),
+      roadSignConcept: this.store
+        .request(
+          findRecord<RoadSignConcept>('road-sign-concept', params.id, {
+            include: [
+              'shapes.dimensions.kind',
+              'shapes.dimensions.unit',
+              'shapes.classification',
+              'defaultShape.dimensions',
+              'defaultShape.classification',
+              'image.file',
+              'variables',
+              'classifications',
+              'zonality.inScheme.concepts',
+              'inScheme.concepts',
+            ],
+          }),
+        )
+        .then((res) => res.content),
+      classifications: this.store
+        .request(findAll<RoadSignCategory>('road-sign-category'))
+        .then((res) => res.content),
     });
   }
   resetController(controller: RoadsignConceptsEditController) {

--- a/app/routes/road-sign-concepts/index.ts
+++ b/app/routes/road-sign-concepts/index.ts
@@ -3,18 +3,20 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import type RoadSignCategory from 'mow-registry/models/road-sign-category';
 import { hash } from 'rsvp';
+import { findAll } from '@warp-drive/legacy/compat/builders';
 
 export default class RoadsignConceptsIndexRoute extends Route {
   @service declare store: Store;
 
   async model() {
     return hash({
-      classifications: this.store.findAll<RoadSignCategory>(
-        'road-sign-category',
-        {
-          reload: true,
-        },
-      ),
+      classifications: this.store
+        .request(
+          findAll<RoadSignCategory>('road-sign-category', {
+            reload: true,
+          }),
+        )
+        .then((res) => res.content),
     });
   }
 }

--- a/app/routes/road-sign-concepts/new.ts
+++ b/app/routes/road-sign-concepts/new.ts
@@ -6,15 +6,15 @@ import RoadSignConcept from 'mow-registry/models/road-sign-concept';
 import type SkosConcept from 'mow-registry/models/skos-concept';
 import { ZON_NON_ZONAL_ID } from 'mow-registry/utils/constants';
 import { hash } from 'rsvp';
+import { findAll, findRecord } from '@warp-drive/legacy/compat/builders';
 
 export default class RoadsignConceptsNewRoute extends Route {
   @service declare store: Store;
 
   async model() {
-    const nonZonalConcept = await this.store.findRecord<SkosConcept>(
-      'skos-concept',
-      ZON_NON_ZONAL_ID,
-    );
+    const nonZonalConcept = await this.store
+      .request(findRecord<SkosConcept>('skos-concept', ZON_NON_ZONAL_ID))
+      .then((res) => res.content);
 
     return hash({
       newRoadSignConcept: this.store.createRecord<RoadSignConcept>(
@@ -23,8 +23,9 @@ export default class RoadsignConceptsNewRoute extends Route {
           zonality: nonZonalConcept,
         },
       ),
-      classifications:
-        this.store.findAll<RoadSignCategory>('road-sign-category'),
+      classifications: this.store
+        .request(findAll<RoadSignCategory>('road-sign-category'))
+        .then((res) => res.content),
     });
   }
 }

--- a/app/routes/road-sign-concepts/road-sign-concept.ts
+++ b/app/routes/road-sign-concepts/road-sign-concept.ts
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 import { TrackedArray } from 'tracked-built-ins';
 import type RoadSignConceptModel from 'mow-registry/models/road-sign-concept';
+import { findRecord } from '@warp-drive/legacy/compat/builders';
 
 type Params = {
   id: string;
@@ -14,29 +15,29 @@ export default class RoadsignConcept extends Route {
 
   async model(params: Params) {
     const data = await hash({
-      roadSignConcept: this.store.findRecord<RoadSignConceptModel>(
-        'road-sign-concept',
-        params.id,
-        {
-          include: [
-            'shapes.dimensions.kind',
-            'shapes.dimensions.unit',
-            'shapes.classification',
-            'defaultShape.dimensions',
-            'defaultShape.classification',
-            'image.file',
-            'variables',
-            'classifications',
-            'zonality.inScheme.concepts',
-            'inScheme.concepts',
-            'relatedToRoadSignConcepts',
-            'relatedFromRoadSignConcepts',
-            'relatedRoadMarkingConcepts',
-            'relatedTrafficLightConcepts',
-            'hasInstructions',
-          ],
-        },
-      ),
+      roadSignConcept: this.store
+        .request(
+          findRecord<RoadSignConceptModel>('road-sign-concept', params.id, {
+            include: [
+              'shapes.dimensions.kind',
+              'shapes.dimensions.unit',
+              'shapes.classification',
+              'defaultShape.dimensions',
+              'defaultShape.classification',
+              'image.file',
+              'variables',
+              'classifications',
+              'zonality.inScheme.concepts',
+              'inScheme.concepts',
+              'relatedToRoadSignConcepts',
+              'relatedFromRoadSignConcepts',
+              'relatedRoadMarkingConcepts',
+              'relatedTrafficLightConcepts',
+              'hasInstructions',
+            ],
+          }),
+        )
+        .then((res) => res.content),
     });
 
     data.roadSignConcept.relatedRoadSignConcepts = new TrackedArray([

--- a/app/routes/road-sign-concepts/road-sign-concept/instructions/edit.ts
+++ b/app/routes/road-sign-concepts/road-sign-concept/instructions/edit.ts
@@ -4,6 +4,7 @@ import { service } from '@ember/service';
 import type Template from 'mow-registry/models/template';
 import type RoadsignConcept from 'mow-registry/routes/road-sign-concepts/road-sign-concept';
 import type { ModelFrom } from 'mow-registry/utils/type-utils';
+import { findRecord } from '@warp-drive/legacy/compat/builders';
 
 type Params = {
   instructionId: string;
@@ -23,13 +24,13 @@ export default class RoadSignConceptsRoadSignConceptInstructionsEditRoute extend
         concept,
       };
     } else {
-      const template = await this.store.findRecord<Template>(
-        'template',
-        params.instructionId,
-        {
-          include: ['variables'],
-        },
-      );
+      const template = await this.store
+        .request(
+          findRecord<Template>('template', params.instructionId, {
+            include: ['variables'],
+          }),
+        )
+        .then((res) => res.content);
       return {
         template,
         roadSignConcept,

--- a/app/routes/road-sign-concepts/road-sign-concept/related.ts
+++ b/app/routes/road-sign-concepts/road-sign-concept/related.ts
@@ -9,6 +9,7 @@ import { service } from '@ember/service';
 import RoadSignCategory from 'mow-registry/models/road-sign-category';
 import type RelatedController from 'mow-registry/controllers/road-sign-concepts/road-sign-concept/related';
 import type Transition from '@ember/routing/transition';
+import { query } from '@warp-drive/legacy/compat/builders';
 
 export default class RoadSignConceptsRoadSignConceptRelatedRoute extends Route {
   @service declare store: Store;
@@ -20,22 +21,24 @@ export default class RoadSignConceptsRoadSignConceptRelatedRoute extends Route {
 
     return hash({
       roadSignConcept,
-      allRoadMarkings: this.store.query<RoadMarkingConcept>(
-        'road-marking-concept',
-        {
-          page: {
-            size: 10000,
-          },
-        },
-      ),
-      allTrafficLights: this.store.query<TrafficLightConcept>(
-        'traffic-light-concept',
-        {
-          page: {
-            size: 10000,
-          },
-        },
-      ),
+      allRoadMarkings: this.store
+        .request(
+          query<RoadMarkingConcept>('road-marking-concept', {
+            page: {
+              size: 10000,
+            },
+          }),
+        )
+        .then((res) => res.content),
+      allTrafficLights: this.store
+        .request(
+          query<TrafficLightConcept>('traffic-light-concept', {
+            page: {
+              size: 10000,
+            },
+          }),
+        )
+        .then((res) => res.content),
       classifications: this.store
         .findAll<RoadSignCategory>('road-sign-category')
         .then((classification) => {

--- a/app/routes/road-sign-concepts/road-sign-concept/sub-signs.ts
+++ b/app/routes/road-sign-concepts/road-sign-concept/sub-signs.ts
@@ -7,6 +7,7 @@ import { service } from '@ember/service';
 import { TrackedArray } from 'tracked-built-ins';
 import type Transition from '@ember/routing/transition';
 import type SubSignsController from 'mow-registry/controllers/road-sign-concepts/road-sign-concept/sub-signs';
+import { query } from '@warp-drive/legacy/compat/builders';
 
 export default class RoadSignConceptsRoadSignConceptSubSignsRoute extends Route {
   @service declare store: Store;
@@ -16,19 +17,20 @@ export default class RoadSignConceptsRoadSignConceptSubSignsRoute extends Route 
       'road-sign-concepts.road-sign-concept',
     ) as ModelFrom<RoadSignConceptRoute>;
 
-    const allSubSigns = await this.store.query<RoadSignConcept>(
-      'road-sign-concept',
-      {
-        filter: {
-          classifications: {
-            label: 'Onderbord',
+    const allSubSigns = (
+      await this.store.request(
+        query<RoadSignConcept>('road-sign-concept', {
+          filter: {
+            classifications: {
+              label: 'Onderbord',
+            },
           },
-        },
-        page: {
-          size: 10000,
-        },
-      },
-    );
+          page: {
+            size: 10000,
+          },
+        }),
+      )
+    ).content;
 
     const relatedSubSigns = await roadSignConcept.subSigns;
 

--- a/app/routes/traffic-light-concepts/edit.ts
+++ b/app/routes/traffic-light-concepts/edit.ts
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 import TrafficlightConceptsEditController from 'mow-registry/controllers/traffic-light-concepts/edit';
 import type TrafficLightConcept from 'mow-registry/models/traffic-light-concept';
 import { hash } from 'rsvp';
+import { findRecord } from '@warp-drive/legacy/compat/builders';
 
 type Params = {
   id: string;
@@ -13,23 +14,23 @@ export default class TrafficLightConceptsEditRoute extends Route {
 
   model(params: Params) {
     return hash({
-      trafficLightConcept: this.store.findRecord<TrafficLightConcept>(
-        'traffic-light-concept',
-        params.id,
-        {
-          include: [
-            'shapes.dimensions.kind',
-            'shapes.dimensions.unit',
-            'shapes.classification',
-            'defaultShape.dimensions',
-            'defaultShape.classification',
-            'image.file',
-            'variables',
-            'zonality.inScheme.concepts',
-            'inScheme.concepts',
-          ],
-        },
-      ),
+      trafficLightConcept: this.store
+        .request(
+          findRecord<TrafficLightConcept>('traffic-light-concept', params.id, {
+            include: [
+              'shapes.dimensions.kind',
+              'shapes.dimensions.unit',
+              'shapes.classification',
+              'defaultShape.dimensions',
+              'defaultShape.classification',
+              'image.file',
+              'variables',
+              'zonality.inScheme.concepts',
+              'inScheme.concepts',
+            ],
+          }),
+        )
+        .then((res) => res.content),
     });
   }
   resetController(controller: TrafficlightConceptsEditController) {

--- a/app/routes/traffic-light-concepts/new.ts
+++ b/app/routes/traffic-light-concepts/new.ts
@@ -5,15 +5,15 @@ import type SkosConcept from 'mow-registry/models/skos-concept';
 import type TrafficLightConcept from 'mow-registry/models/traffic-light-concept';
 import { ZON_NON_ZONAL_ID } from 'mow-registry/utils/constants';
 import { hash } from 'rsvp';
+import { findRecord } from '@warp-drive/legacy/compat/builders';
 
 export default class TrafficlightConceptsNewRoute extends Route {
   @service declare store: Store;
 
   async model() {
-    const nonZonalConcept = await this.store.findRecord<SkosConcept>(
-      'skos-concept',
-      ZON_NON_ZONAL_ID,
-    );
+    const nonZonalConcept = await this.store
+      .request(findRecord<SkosConcept>('skos-concept', ZON_NON_ZONAL_ID))
+      .then((res) => res.content);
     return hash({
       newTrafficLightConcept: this.store.createRecord<TrafficLightConcept>(
         'traffic-light-concept',

--- a/app/routes/traffic-light-concepts/traffic-light-concept.ts
+++ b/app/routes/traffic-light-concepts/traffic-light-concept.ts
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import Store from 'mow-registry/services/store';
 import type TrafficLightConceptModel from 'mow-registry/models/traffic-light-concept';
+import { findRecord } from '@warp-drive/legacy/compat/builders';
 
 type Params = {
   id: string;
@@ -12,24 +13,27 @@ export default class TrafficlightConcept extends Route {
 
   async model(params: Params) {
     return {
-      trafficLightConcept:
-        await this.store.findRecord<TrafficLightConceptModel>(
-          'traffic-light-concept',
-          params.id,
-          {
-            include: [
-              'image.file',
-              'variables',
-              'zonality.inScheme.concepts',
-              'inScheme.concepts',
-              'relatedRoadSignConcepts',
-              'relatedRoadMarkingConcepts',
-              'relatedToTrafficLightConcepts',
-              'relatedFromTrafficLightConcepts',
-              'hasInstructions',
-            ],
-          },
-        ),
+      trafficLightConcept: await this.store
+        .request(
+          findRecord<TrafficLightConceptModel>(
+            'traffic-light-concept',
+            params.id,
+            {
+              include: [
+                'image.file',
+                'variables',
+                'zonality.inScheme.concepts',
+                'inScheme.concepts',
+                'relatedRoadSignConcepts',
+                'relatedRoadMarkingConcepts',
+                'relatedToTrafficLightConcepts',
+                'relatedFromTrafficLightConcepts',
+                'hasInstructions',
+              ],
+            },
+          ),
+        )
+        .then((res) => res.content),
     };
   }
 }

--- a/app/routes/traffic-light-concepts/traffic-light-concept/instruction.ts
+++ b/app/routes/traffic-light-concepts/traffic-light-concept/instruction.ts
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 import type Template from 'mow-registry/models/template';
 import TrafficlightConcept from 'mow-registry/routes/traffic-light-concepts/traffic-light-concept';
 import type { ModelFrom } from 'mow-registry/utils/type-utils';
+import { findRecord } from '@warp-drive/legacy/compat/builders';
 const PARENT_ROUTE = 'traffic-light-concepts.traffic-light-concept.index';
 
 type Params = {
@@ -25,15 +26,13 @@ export default class TrafficLightConceptsTrafficLightConceptInstructionRoute ext
       };
     } else {
       return {
-        template: this.store.findRecord<Template>(
-          'template',
-          params.instruction_id,
-          {
-            // @ts-expect-error we're running into strange type errors with the query argument. Not sure how to fix this properly.
-            // TODO: fix the query types
-            include: 'variables',
-          },
-        ),
+        template: this.store
+          .request(
+            findRecord<Template>('template', params.instruction_id, {
+              include: ['variables'],
+            }),
+          )
+          .then((res) => res.content),
         concept,
         from: PARENT_ROUTE,
       };

--- a/app/routes/traffic-light-concepts/traffic-light-concept/instructions/edit.ts
+++ b/app/routes/traffic-light-concepts/traffic-light-concept/instructions/edit.ts
@@ -4,6 +4,7 @@ import Store from 'mow-registry/services/store';
 import type Template from 'mow-registry/models/template';
 import type TrafficlightConceptRoute from 'mow-registry/routes/traffic-light-concepts/traffic-light-concept';
 import type { ModelFrom } from 'mow-registry/utils/type-utils';
+import { findRecord } from '@warp-drive/legacy/compat/builders';
 
 type Params = {
   instructionId: string;
@@ -23,13 +24,13 @@ export default class TrafficLightConceptsTrafficLightConceptInstructionsEditRout
       };
     } else {
       return {
-        template: this.store.findRecord<Template>(
-          'template',
-          params.instructionId,
-          {
-            include: ['variables'],
-          },
-        ),
+        template: this.store
+          .request(
+            findRecord<Template>('template', params.instructionId, {
+              include: ['variables'],
+            }),
+          )
+          .then((res) => res.content),
         trafficLightConcept,
       };
     }

--- a/app/routes/traffic-light-concepts/traffic-light-concept/related.ts
+++ b/app/routes/traffic-light-concepts/traffic-light-concept/related.ts
@@ -9,6 +9,7 @@ import type TrafficLightConceptRoute from 'mow-registry/routes/traffic-light-con
 import type { ModelFrom } from 'mow-registry/utils/type-utils';
 import { hash } from 'rsvp';
 import { TrackedArray } from 'tracked-built-ins';
+import { query } from '@warp-drive/legacy/compat/builders';
 
 export default class TrafficLightConceptRelatedRoute extends Route {
   @service declare store: Store;
@@ -20,22 +21,24 @@ export default class TrafficLightConceptRelatedRoute extends Route {
 
     const model = await hash({
       trafficLightConcept,
-      allRoadMarkings: this.store.query<RoadMarkingConcept>(
-        'road-marking-concept',
-        {
-          page: {
-            size: 10000,
-          },
-        },
-      ),
-      allTrafficLights: this.store.query<TrafficLightConceptModel>(
-        'traffic-light-concept',
-        {
-          page: {
-            size: 10000,
-          },
-        },
-      ),
+      allRoadMarkings: this.store
+        .request(
+          query<RoadMarkingConcept>('road-marking-concept', {
+            page: {
+              size: 10000,
+            },
+          }),
+        )
+        .then((response) => response.content),
+      allTrafficLights: this.store
+        .request(
+          query<TrafficLightConceptModel>('traffic-light-concept', {
+            page: {
+              size: 10000,
+            },
+          }),
+        )
+        .then((response) => response.content),
       classifications: this.store
         .findAll<RoadSignCategory>('road-sign-category')
         .then((classification) => {

--- a/app/routes/traffic-measure-concepts/details.ts
+++ b/app/routes/traffic-measure-concepts/details.ts
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 import Store from 'mow-registry/services/store';
 import type TrafficMeasureConcept from 'mow-registry/models/traffic-measure-concept';
+import { findRecord } from '@warp-drive/legacy/compat/builders';
 
 type Params = {
   id: string;
@@ -11,11 +12,11 @@ export default class TrafficMeasureConceptsDetailsRoute extends Route {
   @service declare store: Store;
 
   async model(params: Params) {
-    const trafficMeasureConcept =
-      await this.store.findRecord<TrafficMeasureConcept>(
-        'traffic-measure-concept',
-        params.id,
-      );
+    const trafficMeasureConcept = await this.store
+      .request(
+        findRecord<TrafficMeasureConcept>('traffic-measure-concept', params.id),
+      )
+      .then((res) => res.content);
 
     return {
       trafficMeasureConcept,

--- a/app/routes/traffic-measure-concepts/edit.ts
+++ b/app/routes/traffic-measure-concepts/edit.ts
@@ -2,6 +2,7 @@ import Store from 'mow-registry/services/store';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import type TrafficMeasureConcept from 'mow-registry/models/traffic-measure-concept';
+import { findRecord } from '@warp-drive/legacy/compat/builders';
 
 type Params = {
   id: string;
@@ -9,10 +10,11 @@ type Params = {
 export default class TrafficMeasureConceptsEditRoute extends Route {
   @service declare store: Store;
   async model(params: Params) {
-    const trafficMeasureConcept = this.store.findRecord<TrafficMeasureConcept>(
-      'traffic-measure-concept',
-      params.id,
-    );
+    const trafficMeasureConcept = this.store
+      .request(
+        findRecord<TrafficMeasureConcept>('traffic-measure-concept', params.id),
+      )
+      .then((res) => res.content);
     return trafficMeasureConcept;
   }
 }

--- a/app/services/codelists.ts
+++ b/app/services/codelists.ts
@@ -4,6 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import Store from 'mow-registry/services/store';
 import CodeList from 'mow-registry/models/code-list';
+import { query } from '@warp-drive/legacy/compat/builders';
 
 export default class CodelistsService extends Service {
   @tracked codeLists?: CodeList[];
@@ -12,13 +13,15 @@ export default class CodelistsService extends Service {
 
   all = task(async () => {
     if (!this.codeLists) {
-      const codeLists = await this.store.query<CodeList>('code-list', {
-        'page[size]': 100,
-        // @ts-expect-error we're running into strange type errors with the query argument. Not sure how to fix this properly.
-        // TODO: fix the query types
-        include: 'concepts',
-        sort: 'label',
-      });
+      const codeLists = (
+        await this.store.request(
+          query<CodeList>('code-list', {
+            'page[size]': 100,
+            include: ['concepts'],
+            sort: 'label',
+          }),
+        )
+      ).content;
       await Promise.all(codeLists.map((codeList) => codeList.concepts));
 
       this.codeLists = codeLists;

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@warp-drive/json-api": "5.6.0",
     "@warp-drive/legacy": "5.6.0",
     "@warp-drive/schema-record": "5.6.0",
+    "@warp-drive/utilities": "5.6.0",
     "broccoli-asset-rev": "^3.0.0",
     "changesets-release-it-plugin": "^0.1.2",
     "concurrently": "^8.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       '@warp-drive/schema-record':
         specifier: 5.6.0
         version: 5.6.0(@glint/template@1.5.2)
+      '@warp-drive/utilities':
+        specifier: 5.6.0
+        version: 5.6.0(@glint/template@1.5.2)(@warp-drive/core@5.6.0(@glint/template@1.5.2))
       broccoli-asset-rev:
         specifier: ^3.0.0
         version: 3.0.0


### PR DESCRIPTION
## Overview
This PR introduces usage of the new warpdrive `request` API:
- `findAll()` becomes `.request(findAll())`
- `findRecord()` becomes `.request(findRecord())`
- `query()` becomes `.request(query())`
- `.save()` becomes `.request(saveRecord())`

Through the new API, all async requests are made through the `store.request` method. How that request is constructed, is determined by the builders (e.g. `findAll`, `query`...)

While this PR introduces the new request-syntax, it still use the legacy request builders. This means the way requests are made, remains the same, only the syntax has changed. 
You'll notice that the 'legacy' request builders have been marked as deprecated, the goal is to replace these by the new json-api request builders in the future.

**What this PR does not yet include:**
- Removal of models in favour of schema-records: schema-records are not yet documented enough/mature.
- Usage of the new request builders: these are not yet fully documented, and will mostly be compatible with schema-records.

### How to test/reproduce
- Start the app. All requests should be executed in the exact same way as before.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations