### PR TITLE
Feat/add variable signage to filters

### DIFF
--- a/.changeset/tame-bananas-train.md
+++ b/.changeset/tame-bananas-train.md
@@ -1,0 +1,5 @@
+---
+"mow-registry": patch
+---
+
+Add variable signage to filters and details in measures

--- a/app/components/search-tables/traffic-measure.hbs
+++ b/app/components/search-tables/traffic-measure.hbs
@@ -28,6 +28,10 @@
       {{t "utility.zonality"}}
     </th>
     <header.Sortable
+      @field="variableSignage"
+      @label={{t "traffic-measure-concept.attr.variable-signage"}}
+    />
+    <header.Sortable
       @field="valid"
       @label={{t "utility.validation-status"}}
     />
@@ -53,7 +57,15 @@
       {{zonality-label (await trafficMeasureConcept.zonality)}}
     </td>
     <td>
+      {{#if (await trafficMeasureConcept.variableSignage)}}
+        {{t "variable-signage-selector.yes"}}
+      {{else}}
+        {{t "variable-signage-selector.no"}}
+      {{/if}}
+    </td>
+    <td>
       <ValidationStatus @valid={{trafficMeasureConcept.valid}} />
     </td>
+
   </:body>
 </ReactiveTable>

--- a/app/controllers/traffic-measure-concepts/index.ts
+++ b/app/controllers/traffic-measure-concepts/index.ts
@@ -38,6 +38,7 @@ export default class TrafficMeasureConceptsIndexController extends Controller {
   @tracked templateValue = '';
   @tracked sort = ':no-case:label';
   @tracked validation?: string | null;
+  @tracked variableSignage?: string | null;
   @tracked validityOption?: string | null;
   @tracked validityStartDate?: string | null;
   @tracked validityEndDate?: string | null;
@@ -48,10 +49,22 @@ export default class TrafficMeasureConceptsIndexController extends Controller {
       { value: 'false', label: this.intl.t('validation-status.draft') },
     ];
   }
+  get variableSignageOptions() {
+    return [
+      { value: 'true', label: this.intl.t('variable-signage-selector.yes') },
+      { value: 'false', label: this.intl.t('variable-signage-selector.no') },
+    ];
+  }
 
   get selectedValidationStatus() {
     return this.validationStatusOptions.find(
       (option) => option.value === this.validation,
+    );
+  }
+
+  get selectedVariableSignage() {
+    return this.variableSignageOptions.find(
+      (option) => option.value === this.variableSignage,
     );
   }
 
@@ -101,6 +114,7 @@ export default class TrafficMeasureConceptsIndexController extends Controller {
         validityOption: this.validityOption,
         validityStartDate: this.validityStartDate,
         validityEndDate: this.validityEndDate,
+        variableSignage: this.variableSignage,
       },
     );
     query['filter'] = {
@@ -137,6 +151,18 @@ export default class TrafficMeasureConceptsIndexController extends Controller {
   }
 
   @action
+  updateSignageFilter(
+    selectedOption: (typeof this.variableSignageOptions)[number],
+  ) {
+    if (selectedOption) {
+      this.variableSignage = selectedOption.value;
+      this.resetPagination();
+    } else {
+      this.variableSignage = null;
+    }
+  }
+
+  @action
   updateValidityFilter({
     validityOption,
     startDate,
@@ -167,6 +193,7 @@ export default class TrafficMeasureConceptsIndexController extends Controller {
     this.label = '';
     this.templateValue = '';
     this.validation = null;
+    this.variableSignage = null;
     this.validityOption = null;
     this.validityStartDate = null;
     this.validityEndDate = null;

--- a/app/templates/traffic-measure-concepts/details.hbs
+++ b/app/templates/traffic-measure-concepts/details.hbs
@@ -40,6 +40,27 @@
   </Group>
 </AuToolbar>
 <AuBodyContainer @scroll={{true}} class="au-o-box">
+  <div class="au-u-margin-bottom">
+    <AuHeading @level="3" @skin="3" class="au-u-margin-bottom">
+      {{t "utility.properties"}}
+    </AuHeading>
+    <AuHeading @level="5" @skin="5" >
+      {{t "utility.zonality"}}
+    </AuHeading>
+    <p class="au-u-muted">
+       {{zonality-label (await @model.trafficMeasureConcept.zonality)}}
+    </p>
+    <AuHeading @level="5" @skin="5" >
+      {{t "traffic-measure-concept.attr.variable-signage"}}
+    </AuHeading>
+    <p class="au-u-muted">
+      {{#if (await @model.trafficMeasureConcept.variableSignage)}}
+        {{t "variable-signage-selector.yes"}}
+      {{else}}
+        {{t "variable-signage-selector.no"}}
+      {{/if}}
+    </p>
+</div>
   <TrafficMeasure::Preview @signs={{@model.signs}}>
     <:template>
       <TrafficMeasureTemplate @concept={{@model.trafficMeasureConcept}} />

--- a/app/templates/traffic-measure-concepts/index.hbs
+++ b/app/templates/traffic-measure-concepts/index.hbs
@@ -55,6 +55,25 @@
             {{validation.label}}
           </PowerSelect>
         </div>
+        <div>
+          <AuLabel for="variable-signage-filter">
+            {{t "traffic-measure-concept.attr.variable-signage"}}
+          </AuLabel>
+          <PowerSelect
+            @allowClear={{true}}
+            @options={{this.variableSignageOptions}}
+            @selected={{this.selectedVariableSignage}}
+            @placeholder={{t
+              "traffic-measure-concept.crud.variable-signage-filter-placeholder"
+            }}
+            @loadingMessage={{t "utility.loading"}}
+            @onChange={{this.updateSignageFilter}}
+            @triggerId="variable-signage-filter"
+            as |signage|
+          >
+            {{signage.label}}
+          </PowerSelect>
+        </div>
         <ValidityFilters
           @onChange={{this.updateValidityFilter}}
           @value={{this.validityOption}}

--- a/app/utils/fetch-manual-data.ts
+++ b/app/utils/fetch-manual-data.ts
@@ -35,6 +35,7 @@ type Params = {
   sort: string;
   classification?: string | null;
   validation?: string | null;
+  variableSignage?: string | null;
   arPlichtig?: string | null;
   validityOption?: string | null;
   validityStartDate?: string | null;
@@ -80,6 +81,19 @@ export default async function fetchManualData(
       filters.push(`
         FILTER NOT EXISTS {
           ?uri ext:valid ${sparqlEscapeBool(true)}
+        }
+      `);
+    }
+  }
+  if (isSome(params.variableSignage)) {
+    if (params.variableSignage === 'true') {
+      filters.push(`
+        FILTER(?variableSignage = ${sparqlEscapeBool(true)})
+      `);
+    } else {
+      filters.push(`
+        FILTER NOT EXISTS {
+          ?uri mobiliteit:variabeleSignalisatie ${sparqlEscapeBool(true)}
         }
       `);
     }
@@ -141,6 +155,9 @@ export default async function fetchManualData(
       ?uri mobiliteit:Mobiliteitsmaatregelconcept.template ?template.
       ?template ext:preview ?templatePreview.
     }
+    OPTIONAL {
+      ?uri mobiliteit:variabeleSignalisatie ?variableSignage.
+    }
     ${filters.join(' ')}
   `;
   const queryCount = `
@@ -176,16 +193,18 @@ const SORTPARAMETERS = {
   valid: '?valid',
   'ar-plichtig': '?ARplichtig',
   ':no-case:label': 'lcase(?label)',
+  'variable-signage': '?variableSignage',
 };
 
 function generateSortFilter(sort: string): string {
+  console.log(sort);
   let direction;
   let parameter: keyof typeof SORTPARAMETERS;
   if (sort.charAt(0) === '-') {
-    direction = 'ASC';
+    direction = 'DESC';
     parameter = sort.slice(1, sort.length) as keyof typeof SORTPARAMETERS;
   } else {
-    direction = 'DESC';
+    direction = 'ASC';
     parameter = sort as keyof typeof SORTPARAMETERS;
   }
   return `ORDER BY ${direction}(${SORTPARAMETERS[parameter]})`;

--- a/app/utils/fetch-manual-data.ts
+++ b/app/utils/fetch-manual-data.ts
@@ -197,7 +197,6 @@ const SORTPARAMETERS = {
 };
 
 function generateSortFilter(sort: string): string {
-  console.log(sort);
   let direction;
   let parameter: keyof typeof SORTPARAMETERS;
   if (sort.charAt(0) === '-') {

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -252,6 +252,7 @@ traffic-measure-concept:
     type-to-search: Type to search
     validation-filter: Validation
     validation-filter-placeholder: Filter by validation status
+    variable-signage-filter-placeholder: Filter by variable signage
   landing-page:
     content: Manage traffic measures.
     button: Go to traffic measures

--- a/translations/nl-be.yaml
+++ b/translations/nl-be.yaml
@@ -244,6 +244,7 @@ traffic-measure-concept:
     type-to-search: Typ om te zoeken
     validation-filter: Validatie
     validation-filter-placeholder: Filteren op validatie-status
+    variable-signage-filter-placeholder: Filteren op variabele signalisatie
   landing-page:
     content: Beheer mobiliteitsmaatregelen.
     button: Ga naar Mobiliteitsmaatregelen


### PR DESCRIPTION
## Overview
Add variable signage to filters and details on measures, I also changed the direction of the sorting as I noticed that was wrong

##### connected issues and PRs:
GN-5687


### Setup
None

### How to test/reproduce
Check that you can sort on variable signage and filter on it, also check the details of a measure and see that is correctly displayed there, we don't have a design so I tried to make it as clear as I could, but definitely open to suggestions

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations