### PR TITLE
fix: cascade delete traffic-signal-list-items when deleting connected traffic-signal-concept

### DIFF
--- a/.changeset/purple-spies-smile.md
+++ b/.changeset/purple-spies-smile.md
@@ -1,0 +1,5 @@
+---
+"mow-registry": patch
+---
+
+Cascade delete traffic-signal-list-items when deleting connected traffic-signal-concept

--- a/app/models/traffic-signal-concept.ts
+++ b/app/models/traffic-signal-concept.ts
@@ -20,6 +20,7 @@ import {
 } from 'mow-registry/validators/schema';
 import type TribontShape from './tribont-shape';
 import type Variable from './variable';
+import TrafficSignalListItem from './traffic-signal-list-item';
 
 export default class TrafficSignalConcept extends SkosConcept {
   //@ts-expect-error TS doesn't allow subclasses to redefine concrete types. We should try to remove the inheritance chain.
@@ -74,6 +75,20 @@ export default class TrafficSignalConcept extends SkosConcept {
   async destroyWithRelations() {
     // This doesn't delete the status or hasTrafficMeasureConcepts relations as it wasn't clear what
     // the expectation would be for these since they don't appear to be used
+    if (this.uri) {
+      const trafficListItems = await this.store.query<TrafficSignalListItem>(
+        'traffic-signal-list-item',
+        {
+          filter: {
+            item: {
+              ':uri:': this.uri,
+            },
+          },
+        },
+      );
+      await Promise.all(trafficListItems.map((item) => item.destroyRecord()));
+    }
+
     const [variables, image, instructions, shapes] = await Promise.all([
       this.variables,
       this.image,


### PR DESCRIPTION
## Overview
This PR ensures that connected resources of the `traffic-signal-list-item` type are correctly removed when deleting their connected `traffic-signal-concept`.

##### connected issues and PRs:
None

### How to test/reproduce
- Start the app
- Open a signal-concept which is used in a traffic-measure
- Delete the signal-concept
- Visit the traffic-measure which contained the signal-concept
- Ensure the signal-concept is no longer shown in the list of signal-concepts
- If instruction variables were used in the template which used instructions of the removed signal-concept, these should have been cleared

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations