### PR TITLE
Fix proxy access when listing concepts for an instruction codelist var

### DIFF
--- a/.changeset/green-bears-act.md
+++ b/.changeset/green-bears-act.md
@@ -1,0 +1,5 @@
+---
+"mow-registry": patch
+---
+
+Fix bug with display of codelist instruction variables

--- a/app/components/add-instruction.gts
+++ b/app/components/add-instruction.gts
@@ -309,7 +309,7 @@ export default class AddInstructionComponent extends Component<AddInstructionSig
   // This terribly named method exists to prevent prettier from insisting on a newline which
   // prevents the glint-expect-error from functioning. An eslint-disable-next-line doesn't work
   // either as both have to be for the next line. :/
-  getCon = (codelist: CodeList) => codelist.concepts;
+  getCon = (codelist: CodeList) => codelist.get('concepts');
 
   <template>
     <div>


### PR DESCRIPTION
## Overview
This hack should be removable with `getPromiseState`, but it's such an easy fix I thought I'd put it in anyway...

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
- When editing a traffic signal instruction, set a variable type to 'codelist' and see that the possible options appear correctly. Previously this would fail and Ember would need a reload to function again.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations