### PR TITLE
Add irgn name to all the signs

### DIFF
--- a/.changeset/hungry-coins-cry.md
+++ b/.changeset/hungry-coins-cry.md
@@ -1,0 +1,5 @@
+---
+"mow-registry": minor
+---
+
+Add IRGN name to all the traffic signs

--- a/app/components/road-marking-form.hbs
+++ b/app/components/road-marking-form.hbs
@@ -135,6 +135,28 @@
             <ErrorMessage @error={{error}} />
           </AuFormRow>
         {{/let}}
+        {{#let @roadMarkingConcept.error.irgnName as |error|}}
+          <AuFormRow>
+            <AuLabel
+              @error={{error}}
+              for="irgnName"
+              @required={{true}}
+              @requiredLabel={{t "utility.required"}}
+            >
+              {{t "road-marking-concept.attr.irgnName"}}
+            </AuLabel>
+            <AuTextarea
+              @error={{error}}
+              @width="block"
+              class='u-min-h-5'
+              id="irgnName"
+              required="required"
+              value={{@roadMarkingConcept.irgnName}}
+              {{on "input" (fn this.setRoadMarkingConceptValue "irgnName")}}
+            />
+            <ErrorMessage @error={{error}} />
+          </AuFormRow>
+        {{/let}}
         {{#let @roadMarkingConcept.error.startDate as |error|}}
           <AuFormRow>
             <AuLabel @error={{error}} for="startDate">

--- a/app/components/road-sign-form.gts
+++ b/app/components/road-sign-form.gts
@@ -368,6 +368,28 @@ export default class RoadSignFormComponent extends ImageUploadHandlerComponent<A
                 <ErrorMessage @error={{error}} />
               </AuFormRow>
             {{/let}}
+            {{#let (get @roadSignConcept.error 'irgnName') as |error|}}
+              <AuFormRow>
+                <AuLabel
+                  @error={{isSome error}}
+                  for='irgnName'
+                  @required={{true}}
+                  @requiredLabel={{t 'utility.required'}}
+                >
+                  {{t 'road-sign-concept.attr.irgnName'}}
+                </AuLabel>
+                <AuTextarea
+                  @error={{isSome error}}
+                  @width='block'
+                  class='u-min-h-5'
+                  id='irgnName'
+                  required='required'
+                  value={{@roadSignConcept.irgnName}}
+                  {{on 'input' (fn this.setRoadSignConceptValue 'irgnName')}}
+                />
+                <ErrorMessage @error={{error}} />
+              </AuFormRow>
+            {{/let}}
             {{#let (get @roadSignConcept.error 'startDate') as |error|}}
               <AuFormRow>
                 <AuLabel @error={{isSome error}} for='startDate'>

--- a/app/components/traffic-light-form.hbs
+++ b/app/components/traffic-light-form.hbs
@@ -135,6 +135,28 @@
             <ErrorMessage @error={{error}} />
           </AuFormRow>
         {{/let}}
+        {{#let @trafficLightConcept.error.irgnName as |error|}}
+          <AuFormRow>
+            <AuLabel
+              @error={{error}}
+              for="irgnName"
+              @required={{true}}
+              @requiredLabel={{t "utility.required"}}
+            >
+              {{t "traffic-light-concept.attr.irgnName"}}
+            </AuLabel>
+            <AuTextarea
+              @error={{error}}
+              @width="block"
+              class='u-min-h-5'
+              id="irgnName"
+              required="required"
+              value={{@trafficLightConcept.irgnName}}
+              {{on "input" (fn this.setTrafficLightConceptValue "irgnName")}}
+            />
+            <ErrorMessage @error={{error}} />
+          </AuFormRow>
+        {{/let}}
         {{#let @trafficLightConcept.error.startDate as |error|}}
           <AuFormRow>
             <AuLabel

--- a/app/models/traffic-signal-concept.ts
+++ b/app/models/traffic-signal-concept.ts
@@ -17,6 +17,7 @@ import {
   validateStringRequired,
   validateDateOptional,
   validateEndDate,
+  validateStringOptional,
 } from 'mow-registry/validators/schema';
 import type TribontShape from './tribont-shape';
 import type Variable from './variable';
@@ -30,6 +31,7 @@ export default class TrafficSignalConcept extends SkosConcept {
   @attr declare meaning?: string;
   @attr declare valid?: boolean;
   @attr declare arPlichtig?: boolean;
+  @attr declare irgnName?: string;
   @attr('date') declare startDate?: Date;
   @attr('date') declare endDate?: Date;
 
@@ -63,6 +65,7 @@ export default class TrafficSignalConcept extends SkosConcept {
       defaultShape: validateBelongsToOptional(),
       valid: validateBooleanOptional(),
       arPlichtig: validateBooleanOptional(),
+      irgnName: validateStringOptional(),
       startDate: validateDateOptional(),
       endDate: validateEndDate(),
       image: validateBelongsToRequired(),

--- a/app/templates/road-marking-concepts/road-marking-concept.hbs
+++ b/app/templates/road-marking-concepts/road-marking-concept.hbs
@@ -59,10 +59,18 @@
         </div>
         <div>
           <dt class="au-u-h5 au-u-medium">
-            {{t "road-sign-concept.attr.meaning"}}
+            {{t "road-marking-concept.attr.meaning"}}
           </dt>
           <dd class="au-u-muted">
             {{@model.roadMarkingConcept.meaning}}
+          </dd>
+        </div>
+        <div>
+          <dt class="au-u-h5 au-u-medium">
+            {{t "road-marking-concept.attr.irgnName"}}
+          </dt>
+          <dd class="au-u-muted">
+            {{@model.roadMarkingConcept.irgnName}}
           </dd>
         </div>
         <div>

--- a/app/templates/road-sign-concepts/road-sign-concept.hbs
+++ b/app/templates/road-sign-concepts/road-sign-concept.hbs
@@ -80,6 +80,14 @@
             {{@model.roadSignConcept.meaning}}
           </dd>
         </div>
+         <div>
+          <dt class="au-u-h5 au-u-medium">
+            {{t "road-sign-concept.attr.irgnName"}}
+          </dt>
+          <dd class="au-u-muted">
+            {{@model.roadSignConcept.irgnName}}
+          </dd>
+        </div>
         <div>
           <dt class="au-u-h5 au-u-medium">
             {{t "utility.start-date"}}

--- a/app/templates/traffic-light-concepts/traffic-light-concept.hbs
+++ b/app/templates/traffic-light-concepts/traffic-light-concept.hbs
@@ -65,6 +65,14 @@
         </div>
         <div>
           <dt class="au-u-h5 au-u-medium">
+            {{t "road-sign-concept.attr.irgnName"}}
+          </dt>
+          <dd class="au-u-muted">
+            {{@model.trafficLightConcept.irgnName}}
+          </dd>
+        </div>
+        <div>
+          <dt class="au-u-h5 au-u-medium">
             {{t "utility.start-date"}}
           </dt>
           <dd class="au-u-muted">

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -103,6 +103,7 @@ road-sign-concept:
     image-header: Image
     image-url: Image URL
     meaning: Meaning
+    irgnName: IRGN name
     label: Label
     classifications: Classifications
     sub-sign: Possible subsigns
@@ -161,6 +162,7 @@ traffic-light-concept:
   attr:
     image-header: Image
     meaning: Meaning
+    irgnName: IRGN name
     label: Label
     related-traffic-light: Related traffic lights
     related-sign: Related sign
@@ -195,6 +197,7 @@ road-marking-concept:
     image-header: Image
     image-url: Image URL
     meaning: Meaning
+    irgnName: IRGN name
     label: Label
     related-sign: Related road signs
     related-marking: Related road markings

--- a/translations/nl-be.yaml
+++ b/translations/nl-be.yaml
@@ -102,6 +102,7 @@ road-sign-concept:
     image-header: Afbeelding
     image-url: Afbeelding URL
     meaning: Betekenis
+    irgnName: IRGN naam
     label: Label
     classifications: Classificaties
     sub-sign: Mogelijke onderborden
@@ -153,6 +154,7 @@ traffic-light-concept:
   attr:
     image-header: Afbeelding
     meaning: Betekenis
+    irgnName: IRGN naam
     label: Label
     related-sign: Gerelateerde verkeersborden
     related-marking: Gerelateerde wegmarkeringen
@@ -187,6 +189,7 @@ road-marking-concept:
     image-header: Afbeelding
     image-url: Afbeelding URL
     meaning: Betekenis
+    irgnName: IRGN naam
     label: Label
     related-sign: Gerelateerde verkeersborden
     related-marking: Gerelateerde wegmarkeringen


### PR DESCRIPTION
## Overview
Add field IRGN name to set a string to be shown in MOW. I made 2 decisions on which I would like some opinion first the name "IRGN name" and then the fact of adding a textarea, the ticket states that it's going to be a sentence, but I think a textarea gives the user more flexibility and I don't like writing sentences in inputs

##### connected issues and PRs:
GN5723


### Setup
Use the backend branch

### How to test/reproduce
Check that you can add a irgn name in any traffic sign

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations