### PR TITLE
remove leftovers from traffic sign forms and improve performance of shapes screen

### DIFF
--- a/.changeset/twelve-cups-boil.md
+++ b/.changeset/twelve-cups-boil.md
@@ -1,0 +1,5 @@
+---
+"mow-registry": patch
+---
+
+Remove leftover code from traffic sign forms and improve shapes screen performance

--- a/app/components/road-marking-form.ts
+++ b/app/components/road-marking-form.ts
@@ -1,22 +1,13 @@
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { dropTask } from 'ember-concurrency';
-import { tracked } from '@glimmer/tracking';
 import ImageUploadHandlerComponent from './image-upload-handler';
 import type RouterService from '@ember/routing/router-service';
 import RoadMarkingConcept from 'mow-registry/models/road-marking-concept';
 import Store from 'mow-registry/services/store';
 import TrafficSignalConcept from 'mow-registry/models/traffic-signal-concept';
 import type { ModifiableKeysOfType } from 'mow-registry/utils/type-utils';
-import type TribontShape from 'mow-registry/models/tribont-shape';
-import Variable from 'mow-registry/models/variable';
-import type Dimension from 'mow-registry/models/dimension';
-import { removeItem } from 'mow-registry/utils/array';
-import type Shape from 'mow-registry/models/shape';
-import {
-  validateShapes,
-  validateVariables,
-} from 'mow-registry/utils/validate-relations';
+
 import { saveRecord } from '@warp-drive/legacy/compat/builders';
 
 type Args = {
@@ -30,10 +21,6 @@ export default class RoadMarkingFormComponent extends ImageUploadHandlerComponen
   isArray = function isArray(maybeArray: unknown) {
     return Array.isArray(maybeArray);
   };
-
-  @tracked shapesToRemove: TribontShape[] = [];
-  @tracked variablesToRemove: Variable[] = [];
-  dimensionsToRemove: Dimension[] = [];
 
   get isSaving() {
     return this.editRoadMarkingConceptTask.isRunning;
@@ -78,81 +65,14 @@ export default class RoadMarkingFormComponent extends ImageUploadHandlerComponen
     });
   }
 
-  @action
-  async addShape() {
-    const shape = this.store.createRecord<TribontShape>('tribont-shape', {});
-    (await this.args.roadMarkingConcept.shapes).push(shape);
-    return shape;
-  }
-
-  @action
-  async removeShape(shape: TribontShape) {
-    const shapes = await this.args.roadMarkingConcept.shapes;
-    removeItem(shapes, shape);
-    this.shapesToRemove.push(shape);
-  }
-
-  removeDimension = async (shape: TribontShape, dimension: Dimension) => {
-    removeItem(await shape.dimensions, dimension);
-
-    this.dimensionsToRemove.push(dimension);
-  };
-
   editRoadMarkingConceptTask = dropTask(async (event: InputEvent) => {
     event.preventDefault();
 
     const isValid = await this.args.roadMarkingConcept.validate();
-    const areShapesValid = await validateShapes(
-      this.args.roadMarkingConcept.shapes,
-    );
-    const areVariablesValid = await validateVariables(
-      this.args.roadMarkingConcept.variables,
-    );
-    if (isValid && areShapesValid && areVariablesValid) {
+    if (isValid) {
       const imageRecord = await this.saveImage();
       if (imageRecord) this.args.roadMarkingConcept.set('image', imageRecord);
 
-      const savePromises: Promise<unknown>[] = [];
-      savePromises.push(
-        ...(await this.args.roadMarkingConcept.shapes).map(async (shape) => {
-          await Promise.all(
-            (await shape.dimensions).map(async (dimension) => {
-              await this.store.request(saveRecord(dimension));
-            }),
-          );
-          await this.store.request(saveRecord(shape));
-        }),
-      );
-
-      savePromises.push(
-        ...this.shapesToRemove.map(async (shape) => {
-          await Promise.all(
-            (await shape.dimensions).map(async (dimension) => {
-              await dimension.destroyRecord();
-            }),
-          );
-          await shape.destroyRecord();
-        }),
-      );
-      savePromises.push(
-        ...this.dimensionsToRemove.map((dimension) =>
-          dimension.destroyRecord(),
-        ),
-      );
-
-      savePromises.push(
-        ...(await this.args.roadMarkingConcept.variables).map(
-          async (variable) => {
-            await this.store.request(saveRecord(variable));
-          },
-        ),
-      );
-
-      savePromises.push(
-        ...this.variablesToRemove.map((variable) => variable.destroyRecord()),
-      );
-
-      await Promise.all(savePromises);
       await this.store.request(saveRecord(this.args.roadMarkingConcept));
       this.router.transitionTo(
         'road-marking-concepts.road-marking-concept',
@@ -165,29 +85,6 @@ export default class RoadMarkingFormComponent extends ImageUploadHandlerComponen
   setImage(model: TrafficSignalConcept, image: File) {
     super.setImage(model, image);
     void this.args.roadMarkingConcept.validateProperty('image');
-  }
-
-  @action
-  async addVariable() {
-    const newVariable = this.store.createRecord<Variable>('variable', {});
-    (await this.args.roadMarkingConcept.variables).push(newVariable);
-  }
-
-  @action
-  async removeVariable(variable: Variable) {
-    const variables = await this.args.roadMarkingConcept.variables;
-    removeItem(variables, variable);
-    this.variablesToRemove.push(variable);
-  }
-
-  @action
-  async toggleDefaultShape(shape: Shape) {
-    const currentDefault = await this.args.roadMarkingConcept.defaultShape;
-    if (currentDefault && currentDefault.id === shape.id) {
-      this.args.roadMarkingConcept.set('defaultShape', null);
-    } else {
-      this.args.roadMarkingConcept.set('defaultShape', shape);
-    }
   }
 
   willDestroy() {

--- a/app/components/traffic-signal-common/shape-manager.gts
+++ b/app/components/traffic-signal-common/shape-manager.gts
@@ -165,6 +165,7 @@ export default class ShapeManager extends Component<Signature> {
         .request(
           query<TribontShape>('tribont-shape', {
             'filter[:id:]': shapesSorted.ids.join(','),
+            include: ['dimensions.kind', 'dimensions.unit', 'classification'],
           }),
         )
         .then((res) => res.content);

--- a/app/components/traffic-signal-common/shape-manager.gts
+++ b/app/components/traffic-signal-common/shape-manager.gts
@@ -142,7 +142,8 @@ export default class ShapeManager extends Component<Signature> {
       shapes = await this.store
         .request(
           query<TribontShape>('tribont-shape', {
-            'filter[trafficSignalConcept][:id:]': this.args.trafficSignal.id,
+            'filter[traffic-signal-concept][:id:]': this.args.trafficSignal.id,
+            include: ['dimensions.kind', 'dimensions.unit', 'classification'],
             page: {
               number: number,
               size: size,
@@ -222,7 +223,7 @@ export default class ShapeManager extends Component<Signature> {
     ) {
       let shapes = await this.store
         .countAndFetchAll<TribontShape>('tribont-shape', {
-          'filter[trafficSignalConcept][:id:]': this.args.trafficSignal.id,
+          'filter[traffic-signal-concept][:id:]': this.args.trafficSignal.id,
         })
         .then((res) => res.content);
       for (const shape of shapes) {
@@ -241,7 +242,7 @@ export default class ShapeManager extends Component<Signature> {
   changeShape = task(async () => {
     let shapes = await this.store
       .countAndFetchAll<TribontShape>('tribont-shape', {
-        'filter[trafficSignalConcept][:id:]': this.args.trafficSignal.id,
+        'filter[traffic-signal-concept][:id:]': this.args.trafficSignal.id,
       })
       .then((res) => res.content);
     for (const shapeToDelete of shapes) {

--- a/app/components/traffic-signal-common/variable-manager.gts
+++ b/app/components/traffic-signal-common/variable-manager.gts
@@ -115,7 +115,7 @@ export default class VariableManager extends Component<Signature> {
     await Promise.resolve();
     const variables = await this.store.request(
       query<Variable>('variable', {
-        'filter[trafficSignalConcept][:id:]': this.args.trafficSignal.id,
+        'filter[traffic-signal-concept][:id:]': this.args.trafficSignal.id,
         page: {
           number: this.pageNumber,
           size: this.pageSize,


### PR DESCRIPTION

## Overview
Got some merge problems with the shapes PR, this should solve them, also improve some performance of the shapes screen by including the dimensions, kinds and units in the query

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-5692



### Setup
None

### How to test/reproduce
Check that you can now save any traffic sign without problems, and also you can use the shapes screens as before

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations