### PR TITLE
Replace sparql queries to lblod endpoints by get

### DIFF
--- a/.changeset/six-onions-build.md
+++ b/.changeset/six-onions-build.md
@@ -1,0 +1,5 @@
+---
+"mow-registry": patch
+---
+
+Replace sparql queries to lblod endpoints by get

--- a/app/utils/fetch-manual-data.ts
+++ b/app/utils/fetch-manual-data.ts
@@ -211,10 +211,12 @@ export default async function fetchManualData(
   const response = await executeQuery({
     query,
     endpoint: '/raw-sparql',
+    useGet: true,
   });
   const countQuery = await executeCountQuery({
     query: queryCount,
     endpoint: '/raw-sparql',
+    useGet: true,
   });
   const uris = response.results.bindings.map((binding) =>
     binding['id'] ? binding['id'].value : '',

--- a/app/utils/shapes/sorting.ts
+++ b/app/utils/shapes/sorting.ts
@@ -51,10 +51,12 @@ export async function sortOnDimension(
   const response = await executeQuery({
     query: sortQuery,
     endpoint: '/raw-sparql',
+    useGet: true,
   });
   const countQuery = await executeCountQuery({
     query: queryCount,
     endpoint: '/raw-sparql',
+    useGet: true,
   });
   const ids = response.results.bindings.map((binding) =>
     binding['id'] ? binding['id'].value : '',

--- a/app/utils/sparql-utils.ts
+++ b/app/utils/sparql-utils.ts
@@ -15,6 +15,7 @@ interface QueryConfig {
   query: string;
   endpoint: string;
   abortSignal?: AbortSignal;
+  useGet?: boolean;
 }
 
 export const sparqlEscapeString = (value: string) =>

--- a/app/utils/sparql-utils.ts
+++ b/app/utils/sparql-utils.ts
@@ -42,19 +42,33 @@ export async function executeQuery<Binding = Record<string, RDF.Term>>({
   query,
   endpoint,
   abortSignal,
-}: QueryConfig): Promise<QueryResult<Binding>> {
+  useGet,
+}: QueryConfig) {
   const encodedQuery = encodeURIComponent(query.trim());
 
-  const response = await fetch(endpoint, {
-    method: 'POST',
+  const params = new URLSearchParams();
+  params.append('query', query);
+
+  const fetchOptions: RequestInit = {
     mode: 'cors',
     headers: {
       Accept: 'application/sparql-results+json',
-      'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
     },
-    body: `query=${encodedQuery}`,
     signal: abortSignal,
-  });
+  };
+
+  let finalUrl = endpoint;
+
+  if (useGet) {
+    finalUrl = `${endpoint}?${params.toString()}`;
+  } else {
+    fetchOptions.method = 'POST';
+    (fetchOptions.headers as { [key: string]: string })['Content-Type'] =
+      'application/x-www-form-urlencoded; charset=UTF-8';
+    fetchOptions.body = `query=${encodedQuery}`;
+  }
+
+  const response = await fetch(finalUrl, fetchOptions);
 
   if (response.ok) {
     return response.json() as Promise<QueryResult<Binding>>;


### PR DESCRIPTION
## Overview
Change queries to our ENV to GET request due to recent problems

##### connected issues and PRs:
None


### Setup
None

### How to test/reproduce
Check that everything works as before, mainly the signs tables and the shapes 

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations