### PR TITLE
Variable type now links to codelist

### DIFF
--- a/.changeset/solid-paws-rush.md
+++ b/.changeset/solid-paws-rush.md
@@ -1,0 +1,5 @@
+---
+"mow-registry": patch
+---
+
+Variable type now links to codelist when relevant

--- a/app/components/traffic-signal-common/variable-manager.gts
+++ b/app/components/traffic-signal-common/variable-manager.gts
@@ -17,6 +17,7 @@ import { fn } from '@ember/helper';
 import humanFriendlyDate from 'mow-registry/helpers/human-friendly-date';
 import { Await, getPromiseState } from '@warp-drive/ember';
 import type VariablesService from 'mow-registry/services/variables-service';
+import type CodelistVariable from 'mow-registry/models/codelist-variable';
 import { isCodelistVariable } from 'mow-registry/models/codelist-variable';
 import { isSome } from 'mow-registry/utils/option';
 import { isTextVariable } from 'mow-registry/models/text-variable';
@@ -128,6 +129,9 @@ export default class VariableManager extends Component<Signature> {
     this.variableToDelete = undefined;
     this.isDeleteConfirmationOpen = false;
   };
+  asCodelistVariable = (variable: Variable) => {
+    return variable as CodelistVariable;
+  };
 
   <template>
     {{#if this.codelists.isSuccess}}
@@ -172,17 +176,22 @@ export default class VariableManager extends Component<Signature> {
           <td>
             {{#if variable.type}}
               {{#if (eq variable.type 'codelist')}}
-                <Await @promise={{variable.codeList}}>
-                  <:success as |codelist|>
-                    <AuLink
-                      @route='codelists-management.codelist'
-                      @model={{codelist.id}}
-                    >
-                      {{this.labelForType variable.type}}
-                      ({{codelist.label}})
-                    </AuLink>
-                  </:success>
-                </Await>
+                {{#let
+                  (this.asCodelistVariable variable)
+                  as |codelistVariable|
+                }}
+                  <Await @promise={{codelistVariable.codeList}}>
+                    <:success as |codelist|>
+                      <AuLink
+                        @route='codelists-management.codelist'
+                        @model={{codelist.id}}
+                      >
+                        {{this.labelForType codelistVariable.type}}
+                        ({{codelist.label}})
+                      </AuLink>
+                    </:success>
+                  </Await>
+                {{/let}}
               {{else}}
                 {{this.labelForType variable.type}}
               {{/if}}

--- a/app/components/traffic-signal-common/variable-manager.gts
+++ b/app/components/traffic-signal-common/variable-manager.gts
@@ -15,7 +15,7 @@ import t from 'ember-intl/helpers/t';
 import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
 import humanFriendlyDate from 'mow-registry/helpers/human-friendly-date';
-import { getPromiseState } from '@warp-drive/ember';
+import { Await, getPromiseState } from '@warp-drive/ember';
 import type VariablesService from 'mow-registry/services/variables-service';
 import { isCodelistVariable } from 'mow-registry/models/codelist-variable';
 import { isSome } from 'mow-registry/utils/option';
@@ -28,6 +28,8 @@ import { query } from '@warp-drive/legacy/compat/builders';
 import { task } from 'ember-concurrency';
 import ConfirmationModal from 'mow-registry/components/confirmation-modal';
 import perform from 'ember-concurrency/helpers/perform';
+import AuLink from '@appuniversum/ember-appuniversum/components/au-link';
+import { eq } from 'ember-truth-helpers';
 
 interface Signature {
   Args: {
@@ -126,6 +128,7 @@ export default class VariableManager extends Component<Signature> {
     this.variableToDelete = undefined;
     this.isDeleteConfirmationOpen = false;
   };
+
   <template>
     {{#if this.codelists.isSuccess}}
       <ReactiveTable
@@ -168,7 +171,21 @@ export default class VariableManager extends Component<Signature> {
           </td>
           <td>
             {{#if variable.type}}
-              {{this.labelForType variable.type}}
+              {{#if (eq variable.type 'codelist')}}
+                <Await @promise={{variable.codeList}}>
+                  <:success as |codelist|>
+                    <AuLink
+                      @route='codelists-management.codelist'
+                      @model={{codelist.id}}
+                    >
+                      {{this.labelForType variable.type}}
+                      ({{codelist.label}})
+                    </AuLink>
+                  </:success>
+                </Await>
+              {{else}}
+                {{this.labelForType variable.type}}
+              {{/if}}
             {{/if}}
           </td>
           <td>


### PR DESCRIPTION
## Overview
FIxing one of the things I forgot to implement in Saska designs

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-6089


### Setup
None

### How to test/reproduce
Check that if you go to the variables screen of a sign, you can now click on the codelist type of a variable to go to the specified codelist

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations