### PR TITLE
Unify sorting of codelists

### DIFF
--- a/.changeset/dull-ants-hunt.md
+++ b/.changeset/dull-ants-hunt.md
@@ -1,0 +1,5 @@
+---
+"mow-registry": patch
+---
+
+Unify sorting of codelists by making the codelist service sort on no-case label

--- a/app/services/codelists.ts
+++ b/app/services/codelists.ts
@@ -19,7 +19,7 @@ export default class CodelistsService extends Service {
             query<CodeList>('code-list', {
               'page[size]': 100,
               include: ['concepts'],
-              sort: 'label',
+              sort: ':no-case:label',
             }),
           )
           .then((res) => res.content);


### PR DESCRIPTION
## Overview
The codelist service was sorting on label while the codelist management page was sorting them ignoring casing, this created some confusion to the users

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-6090


### Setup
None

### How to test/reproduce
Go to the variables page, open a codelist variable to edit, notice the sorting of the codelist now ignores casing

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations