### PR TITLE
FIx codelist select didn't have the correct error state in variable form

### DIFF
--- a/.changeset/rude-peaches-flow.md
+++ b/.changeset/rude-peaches-flow.md
@@ -1,0 +1,5 @@
+---
+"mow-registry": patch
+---
+
+Fix codelist in edit variable form didn't had the correct error state

--- a/app/components/traffic-signal-common/edit-variable-form.gts
+++ b/app/components/traffic-signal-common/edit-variable-form.gts
@@ -250,23 +250,33 @@ export default class EditVariableForm extends Component<Sig> {
             <AuFormRow>
               <Await @promise={{this.variableToEdit.codeList}}>
                 <:success as |codelist|>
-                  <AuLabel
-                    @required={{true}}
-                    @requiredLabel={{t 'utility.required'}}
-                  >{{t 'variable-manager.edit-modal.codelist'}}</AuLabel>
-                  <PowerSelect
-                    class='au-u-1-1'
-                    @triggerClass='au-u-margin-top-tiny'
-                    @allowClear={{false}}
-                    @searchEnabled={{true}}
-                    @searchField='label'
-                    @options={{or this.codelists.value undefined}}
-                    @selected={{codelist}}
-                    @onChange={{this.updateCodelist}}
-                    as |codeList|
-                  >
-                    {{codeList.label}}
-                  </PowerSelect>
+                  {{#let (get this.variableToEdit.error 'codeList') as |error|}}
+                    <AuLabel
+                      @required={{true}}
+                      @requiredLabel={{t 'utility.required'}}
+                      @error={{isSome error}}
+                    >{{t 'variable-manager.edit-modal.codelist'}}</AuLabel>
+                    <div
+                      class={{if
+                        error
+                        'au-u-1-1 ember-power-select--error'
+                        'au-u-1-1'
+                      }}
+                    >
+                      <PowerSelect
+                        @triggerClass='au-u-margin-top-tiny'
+                        @allowClear={{false}}
+                        @searchEnabled={{true}}
+                        @searchField='label'
+                        @options={{or this.codelists.value undefined}}
+                        @selected={{codelist}}
+                        @onChange={{this.updateCodelist}}
+                        as |codeList|
+                      >
+                        {{codeList.label}}
+                      </PowerSelect>
+                    </div>
+                  {{/let}}
                   {{#if codelist}}
                     <Await @promise={{codelist.concepts}}>
                       <:success as |concepts|>


### PR DESCRIPTION
## Overview
The codelist select was missing the correct error state

##### connected issues and PRs:
https://binnenland.atlassian.net/browse/GN-6088


### Setup
None

### How to test/reproduce
Go to edit variable or create a new one leave the codelist empty and notice that when you save the error state is correct and clear to the user

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
- [x] no new deprecations